### PR TITLE
feat: full text search on questions page

### DIFF
--- a/plugins/qeta-backend/migrations/20230314-search-index.js
+++ b/plugins/qeta-backend/migrations/20230314-search-index.js
@@ -1,0 +1,15 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function up(knex) {
+  await knex.schema.raw(
+    `CREATE INDEX questions_search_content_index ON questions USING GIN (to_tsvector('english', title || ' ' || content))`,
+  );
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function down(knex) {
+  await knex.schema.raw(`DROP INDEX questions_search_content_index`);
+};

--- a/plugins/qeta-backend/migrations/20230314-search-index.js
+++ b/plugins/qeta-backend/migrations/20230314-search-index.js
@@ -2,14 +2,18 @@
  * @param {import('knex').Knex} knex
  */
 exports.up = async function up(knex) {
-  await knex.schema.raw(
-    `CREATE INDEX questions_search_content_index ON questions USING GIN (to_tsvector('english', title || ' ' || content))`,
-  );
+  if (knex.client.config.client === 'pg') {
+    await knex.schema.raw(
+      `CREATE INDEX questions_search_content_index ON questions USING GIN (to_tsvector('english', title || ' ' || content))`,
+    );
+  }
 };
 
 /**
  * @param {import('knex').Knex} knex
  */
 exports.down = async function down(knex) {
-  await knex.schema.raw(`DROP INDEX questions_search_content_index`);
+  if (knex.client.config.client === 'pg') {
+    await knex.schema.raw(`DROP INDEX questions_search_content_index`);
+  }
 };

--- a/plugins/qeta-backend/src/database/DatabaseQetaStore.test.ts
+++ b/plugins/qeta-backend/src/database/DatabaseQetaStore.test.ts
@@ -155,9 +155,14 @@ describe.each(databases.eachSupportedId())(
           content: 'content to search for',
         });
         const ret = await storage.getQuestions('user1', {
-          searchQuery: 'search',
+          searchQuery: 'to search',
         });
         expect(ret?.questions.length).toEqual(1);
+
+        const noQuestions = await storage.getQuestions('user1', {
+          searchQuery: 'missing',
+        });
+        expect(noQuestions?.questions.length).toEqual(0);
       });
 
       it('should fetch questions with specific component', async () => {

--- a/plugins/qeta-backend/src/database/DatabaseQetaStore.test.ts
+++ b/plugins/qeta-backend/src/database/DatabaseQetaStore.test.ts
@@ -147,6 +147,19 @@ describe.each(databases.eachSupportedId())(
         expect(ret?.questions.length).toEqual(2);
       });
 
+      it('should fetch list of questions based on searchQuery', async () => {
+        await insertQuestion(question);
+        await insertQuestion({
+          ...question,
+          title: 'title2',
+          content: 'content to search for',
+        });
+        const ret = await storage.getQuestions('user1', {
+          searchQuery: 'search',
+        });
+        expect(ret?.questions.length).toEqual(1);
+      });
+
       it('should fetch questions with specific component', async () => {
         const q1 = await storage.postQuestion(
           'user1',

--- a/plugins/qeta-backend/src/database/DatabaseQetaStore.ts
+++ b/plugins/qeta-backend/src/database/DatabaseQetaStore.ts
@@ -100,13 +100,17 @@ export class DatabaseQetaStore implements QetaStore {
     }
 
     if (options.searchQuery) {
-      // Only works for postgres but should scale well when used together with the GIN index created in the migration.
-      query.whereRaw(
-        `to_tsvector('english', questions.title || ' ' || questions.content) @@ websearch_to_tsquery(?)`,
-        [`${options.searchQuery}`],
-      );
-      // Works for both postgres and SQLITE but not sure how it would scale for many/large questions.
-      // query.whereRaw('LOWER(questions.content) LIKE LOWER(?)', [`%${options.searchQuery}%`]);
+      if (this.db.client.config.client === 'pg') {
+        query.whereRaw(
+          `to_tsvector('english', questions.title || ' ' || questions.content) @@ websearch_to_tsquery('english', ?)`,
+          [`${options.searchQuery}`],
+        );
+      } else {
+        query.whereRaw(
+          `LOWER(questions.title || ' ' || questions.content) LIKE LOWER(?)`,
+          [`%${options.searchQuery}%`],
+        );
+      }
     }
 
     if (options.tags) {

--- a/plugins/qeta-backend/src/database/DatabaseQetaStore.ts
+++ b/plugins/qeta-backend/src/database/DatabaseQetaStore.ts
@@ -99,6 +99,16 @@ export class DatabaseQetaStore implements QetaStore {
       query.where('questions.author', '=', options.author);
     }
 
+    if (options.searchQuery) {
+      // Only works for postgres but should scale well when used together with the GIN index created in the migration.
+      query.whereRaw(
+        `to_tsvector('english', questions.title || ' ' || questions.content) @@ websearch_to_tsquery(?)`,
+        [`${options.searchQuery}`],
+      );
+      // Works for both postgres and SQLITE but not sure how it would scale for many/large questions.
+      // query.whereRaw('LOWER(questions.content) LIKE LOWER(?)', [`%${options.searchQuery}%`]);
+    }
+
     if (options.tags) {
       query.leftJoin(
         'question_tags',

--- a/plugins/qeta-backend/src/database/QetaStore.ts
+++ b/plugins/qeta-backend/src/database/QetaStore.ts
@@ -73,6 +73,7 @@ export interface QuestionsOptions {
 
   includeTrend?: boolean;
   random?: boolean;
+  searchQuery?: string;
 }
 
 export interface TagResponse {

--- a/plugins/qeta-backend/src/service/router.ts
+++ b/plugins/qeta-backend/src/service/router.ts
@@ -55,6 +55,7 @@ interface QuestionsQuery {
   includeVotes?: boolean;
   includeEntities?: boolean;
   includeTrend?: boolean;
+  searchQuery?: string;
 }
 
 const QuestionsQuerySchema: JSONSchemaType<QuestionsQuery> = {
@@ -79,6 +80,7 @@ const QuestionsQuerySchema: JSONSchemaType<QuestionsQuery> = {
     includeVotes: { type: 'boolean', nullable: true },
     includeEntities: { type: 'boolean', nullable: true },
     includeTrend: { type: 'boolean', nullable: true },
+    searchQuery: { type: 'string', nullable: true },
   },
   required: [],
   additionalProperties: false,

--- a/plugins/qeta/src/api/QetaApi.ts
+++ b/plugins/qeta/src/api/QetaApi.ts
@@ -15,6 +15,7 @@ export type GetQuestionsOptions = {
   entity?: string;
   author?: string;
   favorite?: boolean;
+  searchQuery?: string;
 
   includeEntities?: boolean;
 };

--- a/plugins/qeta/src/components/QuestionsContainer/QuestionsContainer.tsx
+++ b/plugins/qeta/src/components/QuestionsContainer/QuestionsContainer.tsx
@@ -1,6 +1,15 @@
 import { useQetaApi } from '../../utils/hooks';
-import { Box, Collapse, Grid, Typography, Button } from '@material-ui/core';
+import {
+  Box,
+  Collapse,
+  Grid,
+  Typography,
+  Button,
+  TextField,
+} from '@material-ui/core';
+
 import React, { useEffect } from 'react';
+import useDebounce from 'react-use/lib/useDebounce';
 import { FilterKey, filterKeys, FilterPanel } from './FilterPanel';
 import { QuestionList } from './QuestionList';
 import FilterList from '@material-ui/icons/FilterList';
@@ -23,12 +32,14 @@ export const QuestionsContainer = (props: QuestionsContainerProps) => {
   const [questionsPerPage, setQuestionsPerPage] = React.useState(10);
   const [showFilterPanel, setShowFilterPanel] = React.useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
+  const [searchQuery, setSearchQuery] = React.useState('');
   const [filters, setFilters] = React.useState({
     order: 'desc',
     orderBy: 'created',
     noAnswers: 'false',
     noCorrectAnswer: 'false',
     noVotes: 'false',
+    searchQuery: '',
   });
 
   const onPageChange = (value: number) => {
@@ -49,6 +60,14 @@ export const QuestionsContainer = (props: QuestionsContainerProps) => {
       return newValue;
     });
   };
+
+  const onSearchQueryChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(event.target.value);
+  };
+
+  useDebounce(() => setFilters({ ...filters, searchQuery: searchQuery }), 200, [
+    searchQuery,
+  ]);
 
   useEffect(() => {
     let filtersApplied = false;
@@ -127,6 +146,20 @@ export const QuestionsContainer = (props: QuestionsContainerProps) => {
   return (
     <Box>
       {showTitle && <Typography variant="h5">{shownTitle}</Typography>}
+      <Grid container>
+        <Grid item xs={12} md={4}>
+          <TextField
+            id="search-bar"
+            fullWidth
+            onChange={onSearchQueryChange}
+            label="Search for questions"
+            variant="outlined"
+            placeholder="Search..."
+            size="small"
+            style={{ marginBottom: '5px' }}
+          />
+        </Grid>
+      </Grid>
       <Grid container justifyContent="space-between">
         <Grid item>
           <Typography variant="h6">{`${

--- a/plugins/qeta/src/components/QuestionsContainer/QuestionsContainer.tsx
+++ b/plugins/qeta/src/components/QuestionsContainer/QuestionsContainer.tsx
@@ -65,7 +65,7 @@ export const QuestionsContainer = (props: QuestionsContainerProps) => {
     setSearchQuery(event.target.value);
   };
 
-  useDebounce(() => setFilters({ ...filters, searchQuery: searchQuery }), 200, [
+  useDebounce(() => setFilters({ ...filters, searchQuery: searchQuery }), 400, [
     searchQuery,
   ]);
 

--- a/plugins/qeta/src/utils/hooks.ts
+++ b/plugins/qeta/src/utils/hooks.ts
@@ -4,7 +4,7 @@ import {
   IdentityApi,
   identityApiRef,
   useApi,
-  configApiRef
+  configApiRef,
 } from '@backstage/core-plugin-api';
 import { makeStyles } from '@material-ui/core';
 import { CatalogApi } from '@backstage/catalog-client';
@@ -182,7 +182,6 @@ export const useStyles = makeStyles(theme => {
     },
   };
 });
-
 
 // Url resolving logic from https://github.com/backstage/backstage/blob/master/packages/core-components/src/components/Link/Link.tsx
 


### PR DESCRIPTION
Initial implementation on adding full text search for the questions page and need some feedback :)
Also needs some cleanup/tweaking before ready.

Currently this implementation only works when using Postgres as the database as I added a GIN index for the concatenation of the title and content, we can then use the full text search capabilities of Postgres to search for questions based on both the title and content of questions.
However, the basic test I added breaks as this approach is not supported by SQLITE.

I don't know how committed you are to supporting both SQLITE and Postgres going forward but I see some different options.

1. Opt for a simpler solution that is supported by both SQLITE and Postgres, something like `WHERE LOWER(questions.content) LIKE LOWER(%query%)`. (Might not scale that well).
2. Try to do something native for both SQLITE and Postgres (might be very complicated to run separate migrations and detect which database is used)
3. Go with Postgres only implementation, loosing SQLITE support :( (at least for this feature)
4.  Something else entirely?

Thoughts on this? :) 

Also, not used to conventional commits so feel free to let me know if it is not up to par!

