### PR TITLE
fix: filter updated on load when searchQuery not changed

### DIFF
--- a/plugins/qeta/src/components/QuestionsContainer/QuestionsContainer.tsx
+++ b/plugins/qeta/src/components/QuestionsContainer/QuestionsContainer.tsx
@@ -65,9 +65,15 @@ export const QuestionsContainer = (props: QuestionsContainerProps) => {
     setSearchQuery(event.target.value);
   };
 
-  useDebounce(() => setFilters({ ...filters, searchQuery: searchQuery }), 400, [
-    searchQuery,
-  ]);
+  useDebounce(
+    () => {
+      if (filters.searchQuery !== searchQuery) {
+        setFilters({ ...filters, searchQuery: searchQuery });
+      }
+    },
+    400,
+    [searchQuery],
+  );
 
   useEffect(() => {
     let filtersApplied = false;


### PR DESCRIPTION
This fixes the initial flicker when loading the questions page.
The function in the debounce was called on load and set the filter even though the searchQuery was empty, which in turn triggered another api call.

With this change there should be no extra api calls if you type something and then quickly go back to what you had in the search bar before.