### PR TITLE
fix: flickering on questions page due to skeleton

### DIFF
--- a/plugins/qeta/src/components/QuestionsContainer/QuestionList.tsx
+++ b/plugins/qeta/src/components/QuestionsContainer/QuestionList.tsx
@@ -10,10 +10,10 @@ import {
   Tooltip,
   Typography,
 } from '@material-ui/core';
-import { LinkButton } from '@backstage/core-components';
+import { LinkButton, Progress } from '@backstage/core-components';
 import React from 'react';
 import { QuestionListItem } from './QuestionListItem';
-import { Pagination, Skeleton } from '@material-ui/lab';
+import { Pagination } from '@material-ui/lab';
 import { QuestionsResponse } from '../../api';
 import HelpOutline from '@material-ui/icons/HelpOutline';
 
@@ -52,7 +52,7 @@ export const QuestionList = (props: {
   };
 
   if (loading) {
-    return <Skeleton variant="rect" height={200} />;
+    return <Progress />;
   }
 
   if (error || response === undefined) {

--- a/plugins/qeta/src/components/TagPage/TagsContainer.tsx
+++ b/plugins/qeta/src/components/TagPage/TagsContainer.tsx
@@ -8,8 +8,7 @@ import {
 } from '@material-ui/core';
 import React from 'react';
 import { useQetaApi } from '../../utils/hooks';
-import { Skeleton } from '@material-ui/lab';
-import { WarningPanel } from '@backstage/core-components';
+import { WarningPanel, Progress } from '@backstage/core-components';
 import { TagResponse } from '../../api';
 
 export const TagsContainer = () => {
@@ -21,7 +20,7 @@ export const TagsContainer = () => {
   } = useQetaApi(api => api.getTags(), []);
 
   if (loading) {
-    return <Skeleton variant="rect" height={200} />;
+    return <Progress />;
   }
 
   if (error || response === undefined) {


### PR DESCRIPTION
Changing the Skeleton to a progress indicator in the QuestionList seems to take care of the flickering.
The progress indicator starts to show after around 300ms, easy to test by applying network throttling in the chrome devtools.

I don't know if using this goes against a design philosophy, if that is the case just ignore this :) 
If you want to go this route I think there could be more places to change this in.

 