### PR TITLE
fix: Add missing createPermissionIntegrationRouter call

### DIFF
--- a/plugins/qeta-backend/package.json
+++ b/plugins/qeta-backend/package.json
@@ -44,6 +44,7 @@
     "@backstage/errors": "^1.1.5",
     "@backstage/plugin-auth-node": "^0.2.12",
     "@backstage/plugin-permission-common": "^0.7.4",
+    "@backstage/plugin-permission-node": "^0.7.6",
     "@backstage/plugin-search-common": "^1.2.2",
     "@drodil/backstage-plugin-qeta-common": "^1.4.1",
     "@types/express": "*",

--- a/plugins/qeta-backend/src/service/router.ts
+++ b/plugins/qeta-backend/src/service/router.ts
@@ -22,10 +22,12 @@ import {
   BasicPermission,
   PermissionEvaluator,
 } from '@backstage/plugin-permission-common';
+import { createPermissionIntegrationRouter } from '@backstage/plugin-permission-node';
 import {
   qetaCreateAnswerPermission,
   qetaCreateQuestionPermission,
   qetaReadPermission,
+  qetaPermissions,
 } from '@drodil/backstage-plugin-qeta-common';
 
 export interface RouterOptions {
@@ -169,6 +171,10 @@ export async function createRouter({
     });
   };
 
+  const permissionIntegrationRouter = createPermissionIntegrationRouter({
+    permissions: qetaPermissions,
+  });
+
   const checkPermissions = async (
     request: Request<unknown>,
     permission: BasicPermission,
@@ -195,6 +201,8 @@ export async function createRouter({
     logger.info('PONG!');
     response.json({ status: 'ok' });
   });
+
+  router.use(permissionIntegrationRouter);
 
   // GET /questions
   router.get(`/questions`, async (request, response) => {


### PR DESCRIPTION
We (the permission framework maintainers) updated the correct usage of createPermissionIntegrationRouter, but the docs remained outdated. As part of fixing the docs (https://github.com/backstage/backstage/pull/17388) we're making PRs to help fix the issue in community plugins as well.