### PR TITLE
Feat/question summary

### DIFF
--- a/plugins/qeta/package.json
+++ b/plugins/qeta/package.json
@@ -56,6 +56,7 @@
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "file-type": "16.5.4",
+    "dompurify": "^3.0.3",
     "lodash": "^4.17.21",
     "react-hook-form": "^7.41.0",
     "react-mde": "^11.5.0",
@@ -76,6 +77,7 @@
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^12.1.3",
     "@testing-library/user-event": "^14.0.0",
+    "@types/dompurify": "^3.0.0",
     "@types/node": "*",
     "cross-fetch": "^3.1.5",
     "msw": "^0.47.0"

--- a/plugins/qeta/src/components/HomePage/HomePage.tsx
+++ b/plugins/qeta/src/components/HomePage/HomePage.tsx
@@ -106,7 +106,7 @@ export const HomePageContent = () => {
     <Content>
       <Container maxWidth="lg">
         <Grid container spacing={3}>
-          <Grid item md={12} lg={9} xl={10}>
+          <Grid item xs={12} lg={9} xl={10}>
             <ContentHeader title="All questions">
               <MoreMenu />
               <AskQuestionButton />

--- a/plugins/qeta/src/components/QuestionsContainer/QuestionListItem.tsx
+++ b/plugins/qeta/src/components/QuestionsContainer/QuestionListItem.tsx
@@ -10,23 +10,37 @@ import { Link } from '@backstage/core-components';
 import React from 'react';
 // @ts-ignore
 import RelativeTime from 'react-relative-time';
-import { formatEntityName } from '../../utils/utils';
+import DOMPurify from 'dompurify';
+import {
+  formatEntityName,
+  truncate,
+  removeMarkdownFormatting,
+} from '../../utils/utils';
 import { TagsAndEntities } from '../QuestionPage/TagsAndEntities';
 
 export const QuestionListItem = (props: { question: QuestionResponse }) => {
   const { question } = props;
   const theme = useTheme();
+
   return (
     <Card>
       <CardContent>
         <Grid container justifyContent="space-between">
           <Grid item xs={12}>
-            <Typography gutterBottom variant="h5" component="div">
+            <Typography variant="h5" component="div">
               <Link to={`/qeta/questions/${question.id}`}>
                 {question.title}
               </Link>
             </Typography>
           </Grid>
+          <Grid item xs={12}>
+            <Typography variant="caption" noWrap component="div">
+              {DOMPurify.sanitize(
+                truncate(removeMarkdownFormatting(question.content), 150),
+              )}
+            </Typography>
+          </Grid>
+
           <Grid item>
             <Typography variant="body2" display="block">
               By{' '}

--- a/plugins/qeta/src/utils/utils.test.ts
+++ b/plugins/qeta/src/utils/utils.test.ts
@@ -1,0 +1,171 @@
+import { removeMarkdownFormatting, truncate } from './utils';
+
+describe('truncate', () => {
+  it('should truncate a long string and add three dots at the end', () => {
+    const input = 'This is a long string';
+    const expectedOutput = 'This is a...';
+    expect(truncate(input, 10)).toBe(expectedOutput);
+  });
+
+  it('should return the original string if shorter than the length', () => {
+    const input = 'This is a long string';
+    const expectedOutput = 'This is a long string';
+    expect(truncate(input, 25)).toBe(expectedOutput);
+  });
+});
+
+describe('removeMarkdownFormatting', () => {
+  it('should remove HTML tags', () => {
+    const input = '<h1>Hello, world!</h1>';
+    const expectedOutput = 'Hello, world!';
+    expect(removeMarkdownFormatting(input)).toBe(expectedOutput);
+  });
+
+  it('should remove nested HTML tags', () => {
+    const input = '<div class="test"><h1>Hello, world!</h1></div>';
+    const expectedOutput = 'Hello, world!';
+    expect(removeMarkdownFormatting(input)).toBe(expectedOutput);
+  });
+
+  it('should handle inline code blocks', () => {
+    const input = '`console.log("test")`';
+    const expectedOutput = 'console.log("test")';
+    expect(removeMarkdownFormatting(input)).toBe(expectedOutput);
+  });
+
+  it('should handle code blocks defined using ```', () => {
+    const input = `\`\`\`
+    echo "Hello world!"
+    \`\`\`
+    `;
+    const expectedOutput = 'echo "Hello world!"';
+    expect(removeMarkdownFormatting(input)).toBe(expectedOutput);
+  });
+
+  it('should handle code blocks defined using ``` and a language', () => {
+    const input = `\`\`\`bash
+    echo "Hello world!"
+    \`\`\`
+    `;
+    const expectedOutput = 'echo "Hello world!"';
+    expect(removeMarkdownFormatting(input)).toBe(expectedOutput);
+  });
+
+  // Spaces for indentation are kept.
+  it('should handle indented code blocks', () => {
+    const input = `\`\`\`python
+    def main():
+        print("Hello")
+        print("World!")
+    \`\`\`
+    `;
+    const expectedOutput =
+      'def main():         print("Hello")         print("World!")';
+    expect(removeMarkdownFormatting(input)).toBe(expectedOutput);
+  });
+
+  it('should remove the formatting for bold text', () => {
+    const input = '**this is bold**';
+    const expectedOutput = 'this is bold';
+    expect(removeMarkdownFormatting(input)).toBe(expectedOutput);
+  });
+
+  it('should remove the formatting for italic text', () => {
+    const input = '*this is italic*';
+    const expectedOutput = 'this is italic';
+    expect(removeMarkdownFormatting(input)).toBe(expectedOutput);
+  });
+
+  it('should remove the formatting for italic bold text', () => {
+    const input = '***this is italic and bold***';
+    const expectedOutput = 'this is italic and bold';
+    expect(removeMarkdownFormatting(input)).toBe(expectedOutput);
+  });
+
+  it('should remove the formatting for strikethrough', () => {
+    const input = '~~this has a strikethrough~~';
+    const expectedOutput = 'this has a strikethrough';
+    expect(removeMarkdownFormatting(input)).toBe(expectedOutput);
+  });
+
+  it('should remove the formatting for blockquotes', () => {
+    const input = ['> First', '>> Nested', '>>> Nested', '> Second'];
+
+    const expectedOutput = 'First Nested Nested Second';
+    expect(removeMarkdownFormatting(input.join('\n'))).toBe(expectedOutput);
+  });
+
+  it('should remove the formatting for unordered lists', () => {
+    const inputStar = ['* First', '* Second', '* Third'];
+    const inputDash = ['- First', '- Second', '- Third'];
+
+    const expectedOutput = 'First Second Third';
+    expect(removeMarkdownFormatting(inputStar.join('\n'))).toBe(expectedOutput);
+    expect(removeMarkdownFormatting(inputDash.join('\n'))).toBe(expectedOutput);
+  });
+
+  it('should remove the formatting for ordered lists', () => {
+    const input = ['1. First', '2. Second', '3. Third'];
+
+    const expectedOutput = 'First Second Third';
+    expect(removeMarkdownFormatting(input.join('\n'))).toBe(expectedOutput);
+  });
+
+  it('should remove the formatting for images and keep the alt text', () => {
+    const input = '![image of a cat](https://cat.png)';
+
+    const expectedOutput = 'image of a cat';
+    expect(removeMarkdownFormatting(input)).toBe(expectedOutput);
+  });
+
+  it('should remove the formatting for links and keep the description', () => {
+    const input = '[some link to an image](https://cat.png)';
+
+    const expectedOutput = 'some link to an image';
+    expect(removeMarkdownFormatting(input)).toBe(expectedOutput);
+  });
+
+  it('should remove headers', () => {
+    const headers = [
+      '# Header',
+      '## Header',
+      '### Header',
+      '#### Header',
+      '#### Header',
+      '##### Header',
+      '###### Header',
+    ];
+
+    const expectedOutput = 'Header';
+
+    headers.forEach(header => {
+      expect(removeMarkdownFormatting(header)).toBe(expectedOutput);
+    });
+  });
+
+  it('should remove footnotes', () => {
+    const input = ['Note[^1]', '[^1]: Reference'];
+
+    const expectedOutput = 'Note';
+    expect(removeMarkdownFormatting(input.join('\n'))).toBe(expectedOutput);
+  });
+
+  it('should remove newlines and leading/trailing spaces', () => {
+    const input = [
+      '   ',
+      '# Header',
+      '\n',
+      '![image of a cat](https://cat.png)',
+      '\r\n',
+      '* Item1',
+      '* Item2',
+      '* Item3',
+      '\r',
+      '`some code`  ',
+    ];
+
+    const expectedOutput =
+      'Header   image of a cat   Item1 Item2 Item3  some code';
+    expect(removeMarkdownFormatting(input.join('\n'))).toBe(expectedOutput);
+  });
+});

--- a/plugins/qeta/src/utils/utils.ts
+++ b/plugins/qeta/src/utils/utils.ts
@@ -18,3 +18,44 @@ export const getEntityTitle = (entity: Entity): string => {
   const stringified = stringifyEntityRef(entity);
   return formatEntityName(entity.metadata.title ?? stringified) ?? stringified;
 };
+
+export const truncate = (str: string, n: number): string => {
+  return str.length > n ? `${str.slice(0, n - 1)}...` : str;
+};
+
+// Covers many common but not all cases of markdown formatting
+export const removeMarkdownFormatting = (text: string): string => {
+  // Remove horizontal rules
+  let fixed = text.replace(/^(-\s*?|\*\s*?|_\s*?){3,}\s*/gm, '');
+
+  // Remove HTML tags
+  fixed = text.replace(/<[^>]*>/g, '');
+
+  // Handle code blocks defined with a language
+  fixed = fixed.replace(/```[\s\S]*?```/g, match => {
+    return match.replace(/(^```[a-z]*\n)|(```$)/g, '').trim();
+  });
+
+  // Handle inline code blocks and code blocks defined using ```
+  fixed = fixed.replace(/`{1,2}([^`]*)`{1,2}/g, '$1');
+
+  // Remove other markdown formatting
+  fixed = fixed
+    .replace(/(?:\*\*|__)([^\n*]+)(?:\*\*|__)/g, '$1') // Bold
+    .replace(/(?:\*|_)([^\n*]+)(?:\*|_)/g, '$1') // Italic
+    .replace(/(?:~~)([^~]+)(?:~~)/g, '$1') // Strikethrough
+    .replace(/^[ \t]{0,3}>+\s?/gm, '') // Blockquotes
+    .replace(/\[\^.+?\](\: .*?$)?/g, '') // Footnotes
+    .replace(/^([ \t]*)([\*\-\+]|\d+\.)\s+/gm, '') // Lists
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1') // Images
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1') // Links
+    .replace(/^#{1,6}[ \t]+/gm, '') // Headers
+    .replace(/^[=\-]{2,}\s*$/g, '') // Setex style headers
+    .replace(/(?:\r\n|\r|\n)/g, ' ') // Newlines
+    .replace(/(^\s+|\s+$)/g, ''); // Trimming leading and trailing spaces
+
+  // Remove remaining HTML tags
+  fixed = fixed.replace(/<[^>]*>/g, '');
+
+  return fixed;
+};

--- a/plugins/qeta/src/utils/utils.ts
+++ b/plugins/qeta/src/utils/utils.ts
@@ -44,7 +44,7 @@ export const removeMarkdownFormatting = (text: string): string => {
     .replace(/(?:\*\*|__)([^\n*]+)(?:\*\*|__)/g, '$1') // Bold
     .replace(/(?:\*|_)([^\n*]+)(?:\*|_)/g, '$1') // Italic
     .replace(/(?:~~)([^~]+)(?:~~)/g, '$1') // Strikethrough
-    .replace(/^[ \t]{0,3}>+\s?/gm, '') // Blockquotes
+    .replace(/^[>\t]{0,3}>+\s?/gm, '') // Blockquotes
     .replace(/\[\^.+?\](\: .*?$)?/g, '') // Footnotes
     .replace(/^([ \t]*)([\*\-\+]|\d+\.)\s+/gm, '') // Lists
     .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1') // Images

--- a/yarn.lock
+++ b/yarn.lock
@@ -4578,6 +4578,13 @@
     "@types/docker-modem" "*"
     "@types/node" "*"
 
+"@types/dompurify@^3.0.0":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/dompurify/-/dompurify-3.0.2.tgz#c1cd33a475bc49c43c2a7900e41028e2136a4553"
+  integrity sha512-YBL4ziFebbbfQfH5mlC+QTJsvh0oJUrWbmxKMyEdL7emlHJqGR2Qb34TEFKj+VCayBvjKy3xczMFNhugThUsfQ==
+  dependencies:
+    "@types/trusted-types" "*"
+
 "@types/eslint-scope@^3.7.3":
   version "3.7.4"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.4.tgz#37fc1223f0786c39627068a12e94d6e6fc61de16"
@@ -5033,6 +5040,11 @@
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@types/triple-beam/-/triple-beam-1.3.2.tgz#38ecb64f01aa0d02b7c8f4222d7c38af6316fef8"
   integrity sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g==
+
+"@types/trusted-types@*":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.3.tgz#a136f83b0758698df454e328759dbd3d44555311"
+  integrity sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==
 
 "@types/unist@*", "@types/unist@^2.0.0":
   version "2.0.6"
@@ -7737,6 +7749,11 @@ domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.1:
   integrity sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==
   dependencies:
     domelementtype "^2.2.0"
+
+dompurify@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.0.3.tgz#4b115d15a091ddc96f232bcef668550a2f6f1430"
+  integrity sha512-axQ9zieHLnAnHh0sfAamKYiqXMJAVwu+LM/alQ7WDagoWessyWvMSFyW65CqF3owufNu8HBcE4cM2Vflu7YWcQ==
 
 domutils@^2.5.2, domutils@^2.8.0:
   version "2.8.0"


### PR DESCRIPTION
Took a while since I haven't had a lot of time lately but here we go :).

This PR implements a suggestion for how to do this: https://github.com/drodil/backstage-plugin-qeta/issues/50.

I looked at how it is implemented for StackOverflow and tried to mimic that, there the markdown formatting is stripped from the content before truncated and displayed.

DomPurify(same as is used for techdocs) is used to sanitize the content after the formatting is stripped. It is possible to achieve the same outcome using the MarkdownContent component from backstage with some custom styling if that is preferred to adding the dependency .

Might be overkill to strip all this markdown formatting but fortunately it is easily removed if needed.

As seen in this screenshot, some more advanced markdown formatting is not removed, like tables, instead it is just compacted.
![screenshot](https://github.com/drodil/backstage-plugin-qeta/assets/9215529/67cc94f5-20df-42af-8fe5-904464fae416)

Thoughts/feedback on this? :) 

