### PR TITLE
feat(statistics): create user statistics endpoints

### DIFF
--- a/plugins/qeta-backend/package.json
+++ b/plugins/qeta-backend/package.json
@@ -53,6 +53,7 @@
     "ajv": "^8.11.0",
     "ajv-formats": "^2.1.1",
     "body-parser": "^1.20.2",
+    "date-fns": "^2.30.0",
     "express": "^4.17.3",
     "express-promise-router": "^4.1.0",
     "file-type": "16.5.4",

--- a/plugins/qeta-backend/src/database/DatabaseQetaStore.ts
+++ b/plugins/qeta-backend/src/database/DatabaseQetaStore.ts
@@ -13,11 +13,13 @@ import {
   Question,
   Questions,
   QuestionsOptions,
-  Statistic,
-  StatisticsRequestParameters,
   TagResponse,
   Vote,
 } from './QetaStore';
+import {
+  Statistic,
+  StatisticsRequestParameters,
+} from '@drodil/backstage-plugin-qeta-common';
 
 const migrationsDir = resolvePackagePath(
   '@drodil/backstage-plugin-qeta-backend',

--- a/plugins/qeta-backend/src/database/DatabaseQetaStore.ts
+++ b/plugins/qeta-backend/src/database/DatabaseQetaStore.ts
@@ -13,6 +13,8 @@ import {
   Question,
   Questions,
   QuestionsOptions,
+  Statistic,
+  StatisticsRequestParameters,
   TagResponse,
   Vote,
 } from './QetaStore';
@@ -574,6 +576,156 @@ export class DatabaseQetaStore implements QetaStore {
         questionsCount: this.mapToInteger(tag.questionsCount),
       };
     });
+  }
+
+  async getMostUpvotedQuestions({
+    author,
+    options,
+  }: StatisticsRequestParameters): Promise<Statistic[]> {
+    const query = this.db<Statistic>('questions as q')
+      .sum('qv.score as total')
+      .select('q.author')
+      .join('question_votes as qv', 'q.id', 'qv.questionId')
+      .groupBy('q.author')
+      .orderBy('total', 'desc');
+
+    if (author) {
+      query.where('q.author', '=', author);
+    }
+
+    if (options?.period) {
+      query.where('q.created', '>', options.period);
+    }
+
+    if (options?.limit) {
+      query.limit(options.limit);
+    }
+
+    const rows = (await query) as unknown as Statistic[];
+
+    // This can probably be replaced to use
+    // DENSE_RANK() over (total) directly by the  query
+    rows.map((row, index) => {
+      row.position = `${index + 1}`;
+    });
+
+    return rows;
+  }
+
+  async getTotalQuestions({
+    author,
+    options,
+  }: StatisticsRequestParameters): Promise<Statistic[]> {
+    const query = this.db<Statistic>('questions as q')
+      .count('q.id as total')
+      .select('q.author')
+      .groupBy('author');
+
+    if (author) {
+      query.where('q.author', '=', author);
+    }
+
+    if (options?.period) {
+      query.where('q.created', '>', options.period);
+    }
+
+    const rows = await query;
+
+    return rows;
+  }
+
+  async getMostUpvotedAnswers({
+    author,
+    options,
+  }: StatisticsRequestParameters): Promise<Statistic[]> {
+    const query = this.db<Statistic>('answers as a')
+      .sum('av.score as total')
+      .select('a.author')
+      .join('answer_votes as av', 'a.id', 'av.answerId')
+      .groupBy('a.author')
+      .orderBy('total', 'desc');
+
+    if (author) {
+      query.where('a.author', '=', author);
+    }
+
+    if (options?.period) {
+      query.where('a.created', '>', options.period);
+    }
+
+    if (options?.limit) {
+      query.limit(options.limit);
+    }
+
+    const rows = (await query) as unknown as Statistic[];
+
+    rows.map((row, index) => {
+      row.position = `${index + 1}`;
+    });
+
+    return rows;
+  }
+
+  async getMostUpvotedCorrectAnswers({
+    author,
+    options,
+  }: StatisticsRequestParameters): Promise<Statistic[]> {
+    const query = this.db<Statistic>('answers as a')
+      .sum('av.score as total')
+      .select('a.author')
+      .join('answer_votes as av', 'a.id', 'av.answerId')
+      .groupBy('a.author')
+      .orderBy('total', 'desc')
+      .where('a.correct', '=', true);
+
+    if (author) {
+      query.where('a.author', '=', author);
+    }
+
+    if (options?.period) {
+      query.where('a.created', '>', options.period);
+    }
+
+    if (options?.limit) {
+      query.limit(options.limit);
+    }
+
+    const rows = (await query) as unknown as Statistic[];
+
+    rows.map((row, index) => {
+      row.position = `${index + 1}`;
+    });
+
+    return rows;
+  }
+
+  async getTotalAnswers({
+    author,
+    options,
+  }: StatisticsRequestParameters): Promise<Statistic[]> {
+    const query = this.db<Statistic>('answers as a')
+      .count('a.id as total')
+      .select('a.author')
+      .groupBy('author');
+
+    if (author) {
+      query.where('a.author', '=', author);
+    }
+
+    if (options?.period) {
+      query.where('a.created', '>', options.period);
+    }
+    if (options?.limit) {
+      query.limit(options.limit);
+    }
+
+    const rows = (await query) as unknown as Statistic[];
+
+    rows.map((row, index) => {
+      row.position = `${index + 1}`;
+    });
+
+    return rows;
   }
 
   async postAttachment({

--- a/plugins/qeta-backend/src/database/QetaStore.ts
+++ b/plugins/qeta-backend/src/database/QetaStore.ts
@@ -1,3 +1,8 @@
+import {
+  Statistic,
+  StatisticsRequestParameters,
+} from '@drodil/backstage-plugin-qeta-common';
+
 export interface Question {
   id: number;
   author: string;
@@ -60,17 +65,6 @@ export interface Questions {
   total: number;
 }
 
-export interface StatisticResponse {
-  ranking: Statistic[];
-  loggedUser?: Statistic;
-}
-
-export interface Statistic {
-  author?: string;
-  total?: number;
-  position?: string;
-}
-
 export interface QuestionsOptions {
   limit?: number;
   offset?: number;
@@ -125,16 +119,6 @@ export interface AttachmentParameters {
   creator?: string;
 }
 
-export interface StatisticsOptions {
-  limit?: number;
-  period?: string;
-  loggedUser?: string;
-}
-
-export interface StatisticsRequestParameters {
-  author?: string;
-  options?: StatisticsOptions;
-}
 /**
  * Interface for fetching and modifying Q&A data
  */

--- a/plugins/qeta-backend/src/database/QetaStore.ts
+++ b/plugins/qeta-backend/src/database/QetaStore.ts
@@ -60,6 +60,17 @@ export interface Questions {
   total: number;
 }
 
+export interface StatisticResponse {
+  ranking: Statistic[];
+  loggedUser?: Statistic;
+}
+
+export interface Statistic {
+  author?: string;
+  total?: number;
+  position?: string;
+}
+
 export interface QuestionsOptions {
   limit?: number;
   offset?: number;
@@ -114,6 +125,16 @@ export interface AttachmentParameters {
   creator?: string;
 }
 
+export interface StatisticsOptions {
+  limit?: number;
+  period?: string;
+  loggedUser?: string;
+}
+
+export interface StatisticsRequestParameters {
+  author?: string;
+  options?: StatisticsOptions;
+}
 /**
  * Interface for fetching and modifying Q&A data
  */
@@ -361,4 +382,25 @@ export interface QetaStore {
   }: AttachmentParameters): Promise<Attachment>;
 
   getAttachment(uuid: string): Promise<Attachment | undefined>;
+
+  getMostUpvotedQuestions({
+    author,
+    options,
+  }: StatisticsRequestParameters): Promise<Statistic[]>;
+  getTotalQuestions({
+    author,
+    options,
+  }: StatisticsRequestParameters): Promise<Statistic[]>;
+  getMostUpvotedAnswers({
+    author,
+    options,
+  }: StatisticsRequestParameters): Promise<Statistic[]>;
+  getMostUpvotedCorrectAnswers({
+    author,
+    options,
+  }: StatisticsRequestParameters): Promise<Statistic[]>;
+  getTotalAnswers({
+    author,
+    options,
+  }: StatisticsRequestParameters): Promise<Statistic[]>;
 }

--- a/plugins/qeta-backend/src/service/router.test.ts
+++ b/plugins/qeta-backend/src/service/router.test.ts
@@ -80,6 +80,11 @@ describe('createRouter', () => {
     unfavoriteQuestion: jest.fn(),
     postAttachment: jest.fn(),
     getAttachment: jest.fn(),
+    getMostUpvotedAnswers: jest.fn(),
+    getTotalAnswers: jest.fn(),
+    getMostUpvotedQuestions: jest.fn(),
+    getMostUpvotedCorrectAnswers: jest.fn(),
+    getTotalQuestions: jest.fn(),
   };
 
   const getIdentityMock = jest

--- a/plugins/qeta-backend/src/service/router.ts
+++ b/plugins/qeta-backend/src/service/router.ts
@@ -36,8 +36,12 @@ import {
   MaybeQuestion,
   QetaStore,
   QuestionsOptions,
+  Statistic,
+  StatisticResponse,
+  StatisticsOptions,
 } from '../database/QetaStore';
 import { File } from './upload/types';
+import { stringDateTime } from '../utils/utils';
 
 export interface RouterOptions {
   identity: IdentityApi;
@@ -863,6 +867,192 @@ export async function createRouter({
     }
     return response.status(404).send('Attachment not found');
   });
+
+  // GET /statistics/questions/top-upvoted-users?period=x&limit=x&loggedUser=x
+  router.get(
+    '/statistics/questions/top-upvoted-users',
+    async (request, response) => {
+      const { period, limit, loggedUser } = request.query;
+
+      const options: StatisticsOptions = {
+        period: period && stringDateTime(period?.toString()),
+        limit: Number(limit),
+        loggedUser: loggedUser?.toString(),
+      };
+
+      const mostUpvotedQuestions: Statistic[] =
+        await database.getMostUpvotedQuestions({
+          options,
+        });
+
+      const rankingResponse = {
+        ranking: mostUpvotedQuestions,
+        loggedUser: {},
+      } as StatisticResponse;
+
+      if (mostUpvotedQuestions.length === 0) {
+        return response.status(204).json(rankingResponse);
+      }
+
+      if (loggedUser) {
+        const findLoggerUserInData = mostUpvotedQuestions.find(userStats => {
+          return userStats.author?.includes(loggedUser.toString());
+        });
+
+        if (!findLoggerUserInData) {
+          const userRef = `user:default/${loggedUser.toString()}`;
+          const loggedUserUpvotedQuestions =
+            await database.getMostUpvotedQuestions({
+              author: userRef,
+              options,
+            });
+
+          if (loggedUserUpvotedQuestions) {
+            rankingResponse.loggedUser!.author =
+              loggedUserUpvotedQuestions.length > 0
+                ? loggedUserUpvotedQuestions[0].author
+                : userRef;
+
+            rankingResponse.loggedUser!.total =
+              loggedUserUpvotedQuestions.length > 0
+                ? loggedUserUpvotedQuestions[0].total
+                : 0;
+
+            rankingResponse.loggedUser!.position = `${mostUpvotedQuestions.length}+`;
+          }
+        } else {
+          rankingResponse.loggedUser = findLoggerUserInData;
+        }
+      }
+
+      return response.status(200).json(rankingResponse);
+    },
+  );
+
+  // GET /statistics/answers/top-upvoted-users?period=x&limit=x&loggedUser=x
+  router.get(
+    '/statistics/answers/top-upvoted-users',
+    async (request, response) => {
+      const { period, limit, loggedUser } = request.query;
+
+      const options: StatisticsOptions = {
+        period: period && stringDateTime(period?.toString()),
+        limit: Number(limit),
+        loggedUser: loggedUser?.toString(),
+      };
+
+      const mostUpvotedAnswers: Statistic[] =
+        await database.getMostUpvotedAnswers({
+          options,
+        });
+
+      const rankingResponse = {
+        ranking: mostUpvotedAnswers,
+        loggedUser: {},
+      } as StatisticResponse;
+
+      if (mostUpvotedAnswers.length === 0) {
+        return response.status(204).json(rankingResponse);
+      }
+
+      if (loggedUser) {
+        const findLoggerUserInData = mostUpvotedAnswers.find(userStats => {
+          return userStats.author?.includes(loggedUser.toString());
+        });
+
+        if (!findLoggerUserInData) {
+          const userRef = `user:default/${loggedUser.toString()}`;
+          const loggedUserUpvotedAnswers = await database.getMostUpvotedAnswers(
+            {
+              author: userRef,
+              options,
+            },
+          );
+
+          if (loggedUserUpvotedAnswers) {
+            rankingResponse.loggedUser!.author =
+              loggedUserUpvotedAnswers.length > 0
+                ? loggedUserUpvotedAnswers[0].author
+                : userRef;
+
+            rankingResponse.loggedUser!.total =
+              loggedUserUpvotedAnswers.length > 0
+                ? loggedUserUpvotedAnswers[0].total
+                : 0;
+
+            rankingResponse.loggedUser!.position = `${mostUpvotedAnswers.length}+`;
+          }
+        } else {
+          rankingResponse.loggedUser = findLoggerUserInData;
+        }
+      }
+
+      return response.status(200).json(rankingResponse);
+    },
+  );
+
+  // GET /statistics/answers/gi?period=x&limit=x&loggedUser=x
+  router.get(
+    '/statistics/answers/top-correct-upvoted-users',
+    async (request, response) => {
+      const { period, limit, loggedUser } = request.query;
+
+      const options: StatisticsOptions = {
+        period: period && stringDateTime(period?.toString()),
+        limit: Number(limit),
+        loggedUser: loggedUser?.toString(),
+      };
+
+      const mostUpvotedCorrectAnswers: Statistic[] =
+        await database.getMostUpvotedCorrectAnswers({
+          options,
+        });
+
+      const rankingResponse = {
+        ranking: mostUpvotedCorrectAnswers,
+        loggedUser: {},
+      } as StatisticResponse;
+
+      if (mostUpvotedCorrectAnswers.length === 0) {
+        return response.status(204).json(rankingResponse);
+      }
+
+      if (loggedUser) {
+        const findLoggerUserInData = mostUpvotedCorrectAnswers.find(
+          userStats => {
+            return userStats.author?.includes(loggedUser.toString());
+          },
+        );
+
+        if (!findLoggerUserInData) {
+          const userRef = `user:default/${loggedUser.toString()}`;
+          const loggedUserUpvotedCorrectAnswers =
+            await database.getMostUpvotedCorrectAnswers({
+              author: userRef,
+              options,
+            });
+
+          if (loggedUserUpvotedCorrectAnswers) {
+            rankingResponse.loggedUser!.author =
+              loggedUserUpvotedCorrectAnswers.length > 0
+                ? loggedUserUpvotedCorrectAnswers[0].author
+                : userRef;
+
+            rankingResponse.loggedUser!.total =
+              loggedUserUpvotedCorrectAnswers.length > 0
+                ? loggedUserUpvotedCorrectAnswers[0].total
+                : 0;
+
+            rankingResponse.loggedUser!.position = `${mostUpvotedCorrectAnswers.length}+`;
+          }
+        } else {
+          rankingResponse.loggedUser = findLoggerUserInData;
+        }
+      }
+
+      return response.status(200).json(rankingResponse);
+    },
+  );
 
   router.use(errorHandler());
   return router;

--- a/plugins/qeta-backend/src/service/router.ts
+++ b/plugins/qeta-backend/src/service/router.ts
@@ -991,7 +991,7 @@ export async function createRouter({
     },
   );
 
-  // GET /statistics/answers/gi?period=x&limit=x&loggedUser=x
+  // GET /statistics/answers/top-correct-upvoted-users?period=x&limit=x&loggedUser=x
   router.get(
     '/statistics/answers/top-correct-upvoted-users',
     async (request, response) => {

--- a/plugins/qeta-backend/src/service/standaloneServer.ts
+++ b/plugins/qeta-backend/src/service/standaloneServer.ts
@@ -33,6 +33,24 @@ export interface ServerOptions {
   logger: Logger;
 }
 
+const getRandomMarvelCharacter = () => {
+  const characters: string[] = [
+    'user:default/iron_man',
+    'user:default/captain_america',
+    'user:default/thor',
+    'user:default/hulk',
+    'user:default/black_widow',
+    'user:default/spider_man',
+    'user:default/black_panther',
+    'user:default/doctor_strange',
+    'user:default/captain_marvel',
+    'user:default/scarlet_witch',
+  ];
+
+  const randomIndex = Math.floor(Math.random() * characters.length);
+  return characters[randomIndex];
+};
+
 export async function startStandaloneServer(
   options: ServerOptions,
 ): Promise<Server> {
@@ -56,7 +74,7 @@ export async function startStandaloneServer(
         identity: {
           type: 'user',
           ownershipEntityRefs: [],
-          userEntityRef: token || 'user:default/john_doe',
+          userEntityRef: token || getRandomMarvelCharacter(),
         },
         token: token || 'no-token',
       };

--- a/plugins/qeta-backend/src/utils/utils.ts
+++ b/plugins/qeta-backend/src/utils/utils.ts
@@ -1,0 +1,12 @@
+import { subDays, format } from 'date-fns';
+
+export const stringDateTime = (dayString: string) => {
+  const dateTimePeriod = Number(dayString.toString().slice(0, -1));
+
+  const formattedDate = format(
+    subDays(new Date(), dateTimePeriod),
+    'yyyy-MM-dd',
+  );
+
+  return formattedDate;
+};

--- a/plugins/qeta-common/src/index.ts
+++ b/plugins/qeta-common/src/index.ts
@@ -1,1 +1,2 @@
 export * from './permissions';
+export * from './types';

--- a/plugins/qeta-common/src/types.ts
+++ b/plugins/qeta-common/src/types.ts
@@ -1,0 +1,21 @@
+export interface StatisticResponse {
+  ranking: Statistic[];
+  loggedUser?: Statistic;
+}
+
+export interface Statistic {
+  author?: string;
+  total?: number;
+  position?: string;
+}
+
+export interface StatisticsOptions {
+  limit?: number;
+  period?: string;
+  loggedUser?: string;
+}
+
+export interface StatisticsRequestParameters {
+  author?: string;
+  options?: StatisticsOptions;
+}

--- a/plugins/qeta/src/api/QetaApi.ts
+++ b/plugins/qeta/src/api/QetaApi.ts
@@ -1,4 +1,8 @@
 import {
+  StatisticResponse,
+  StatisticsRequestParameters,
+} from '@drodil/backstage-plugin-qeta-common';
+import {
   AnswerRequest,
   AnswerResponse,
   AnswerResponseBody,
@@ -6,8 +10,6 @@ import {
   QuestionRequest,
   QuestionResponse,
   QuestionsResponse,
-  StatisticResponse,
-  StatisticsRequestParameters,
   TagResponse,
 } from './types';
 

--- a/plugins/qeta/src/api/QetaApi.ts
+++ b/plugins/qeta/src/api/QetaApi.ts
@@ -6,6 +6,8 @@ import {
   QuestionRequest,
   QuestionResponse,
   QuestionsResponse,
+  StatisticResponse,
+  StatisticsRequestParameters,
   TagResponse,
 } from './types';
 
@@ -42,6 +44,21 @@ export interface QetaApi {
   getQuestion(id: string | undefined): Promise<QuestionResponse>;
 
   getTags(): Promise<TagResponse[]>;
+
+  getMostUpvotedQuestions({
+    author,
+    options,
+  }: StatisticsRequestParameters): Promise<StatisticResponse>;
+
+  getMostUpvotedAnswers({
+    author,
+    options,
+  }: StatisticsRequestParameters): Promise<StatisticResponse>;
+
+  getMostUpvotedCorrectAnswers({
+    author,
+    options,
+  }: StatisticsRequestParameters): Promise<StatisticResponse>;
 
   voteQuestionUp(id: number): Promise<QuestionResponse>;
 

--- a/plugins/qeta/src/api/QetaClient.ts
+++ b/plugins/qeta/src/api/QetaClient.ts
@@ -500,7 +500,7 @@ export class QetaClient implements QetaApi {
   async getMostUpvotedQuestions(
     options: StatisticsRequestParameters,
   ): Promise<StatisticResponse> {
-    const query = this.getQueryParameters(Option).toString();
+    const query = this.getQueryParameters(options).toString();
 
     let url = `${this.baseUrl}/api/qeta/statistics/answers/top-correct-upvoted-users`;
 

--- a/plugins/qeta/src/api/QetaClient.ts
+++ b/plugins/qeta/src/api/QetaClient.ts
@@ -11,6 +11,8 @@ import {
   QuestionResponseBody,
   QuestionsResponse,
   QuestionsResponseBody,
+  StatisticResponse,
+  StatisticsRequestParameters,
   TagResponse,
 } from './types';
 import omitBy from 'lodash/omitBy';
@@ -459,6 +461,58 @@ export class QetaClient implements QetaApi {
 
     const response = await fetch(qetaUrl, requestOptions);
     return (await response.json()) as AttachmentResponseBody;
+  }
+
+  async getMostUpvotedAnswers(
+    options: StatisticsRequestParameters,
+  ): Promise<StatisticResponse> {
+    const query = this.getQueryParameters(options).toString();
+
+    let url = `${this.baseUrl}/api/qeta/statistics/answers/top-upvoted-users`;
+    if (query) {
+      url += `?${query}`;
+    }
+
+    const response = await this.fetchApi.fetch(url);
+
+    const data = (await response.json()) as StatisticResponse;
+
+    return data;
+  }
+
+  async getMostUpvotedCorrectAnswers(
+    options: StatisticsRequestParameters,
+  ): Promise<StatisticResponse> {
+    const query = this.getQueryParameters(options).toString();
+    let url = `${this.baseUrl}/api/qeta/statistics/answers/top-correct-upvoted-users`;
+
+    if (query) {
+      url += `?${query}`;
+    }
+
+    const response = await this.fetchApi.fetch(url);
+
+    const data = (await response.json()) as StatisticResponse;
+
+    return data;
+  }
+
+  async getMostUpvotedQuestions(
+    options: StatisticsRequestParameters,
+  ): Promise<StatisticResponse> {
+    const query = this.getQueryParameters(Option).toString();
+
+    let url = `${this.baseUrl}/api/qeta/statistics/answers/top-correct-upvoted-users`;
+
+    if (query) {
+      url += `?${query}`;
+    }
+
+    const response = await this.fetchApi.fetch(url);
+
+    const data = (await response.json()) as StatisticResponse;
+
+    return data;
   }
 
   private getQueryParameters(params: any): URLSearchParams {

--- a/plugins/qeta/src/api/QetaClient.ts
+++ b/plugins/qeta/src/api/QetaClient.ts
@@ -11,12 +11,14 @@ import {
   QuestionResponseBody,
   QuestionsResponse,
   QuestionsResponseBody,
-  StatisticResponse,
-  StatisticsRequestParameters,
   TagResponse,
 } from './types';
 import omitBy from 'lodash/omitBy';
 import isEmpty from 'lodash/isEmpty';
+import {
+  StatisticResponse,
+  StatisticsRequestParameters,
+} from '@drodil/backstage-plugin-qeta-common';
 
 export const qetaApiRef = createApiRef<QetaApi>({
   id: 'plugin.qeta.service',

--- a/plugins/qeta/src/api/types.ts
+++ b/plugins/qeta/src/api/types.ts
@@ -24,7 +24,7 @@ export interface CommentResponse {
   updatedBy?: string;
 }
 
-export type QuestionsResponseBody = QuestionsResponse | any[];
+export type QuestionsResponseBody = QuestionsResponse | ErrorResponse;
 
 export interface QuestionResponse {
   id: number;

--- a/plugins/qeta/src/api/types.ts
+++ b/plugins/qeta/src/api/types.ts
@@ -108,25 +108,3 @@ export interface AttachmentResponse {
 }
 
 export type AttachmentResponseBody = AttachmentResponse | ErrorResponse;
-
-export interface StatisticResponse {
-  ranking: Statistic[];
-  loggedUser?: Statistic;
-}
-
-export interface Statistic {
-  author?: string;
-  total?: number;
-  position?: string;
-}
-
-export interface StatisticsOptions {
-  limit?: number;
-  period?: string;
-  loggedUser?: string;
-}
-
-export interface StatisticsRequestParameters {
-  author?: string;
-  options?: StatisticsOptions;
-}

--- a/plugins/qeta/src/api/types.ts
+++ b/plugins/qeta/src/api/types.ts
@@ -24,7 +24,7 @@ export interface CommentResponse {
   updatedBy?: string;
 }
 
-export type QuestionsResponseBody = QuestionsResponse | ErrorResponse;
+export type QuestionsResponseBody = QuestionsResponse | any[];
 
 export interface QuestionResponse {
   id: number;
@@ -108,3 +108,25 @@ export interface AttachmentResponse {
 }
 
 export type AttachmentResponseBody = AttachmentResponse | ErrorResponse;
+
+export interface StatisticResponse {
+  ranking: Statistic[];
+  loggedUser?: Statistic;
+}
+
+export interface Statistic {
+  author?: string;
+  total?: number;
+  position?: string;
+}
+
+export interface StatisticsOptions {
+  limit?: number;
+  period?: string;
+  loggedUser?: string;
+}
+
+export interface StatisticsRequestParameters {
+  author?: string;
+  options?: StatisticsOptions;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3723,6 +3723,7 @@ __metadata:
     ajv: ^8.11.0
     ajv-formats: ^2.1.1
     body-parser: ^1.20.2
+    date-fns: ^2.30.0
     express: ^4.17.3
     express-promise-router: ^4.1.0
     file-type: 16.5.4
@@ -9815,7 +9816,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns@npm:^2.16.1, date-fns@npm:^2.29.1":
+"date-fns@npm:^2.16.1, date-fns@npm:^2.29.1, date-fns@npm:^2.30.0":
   version: 2.30.0
   resolution: "date-fns@npm:2.30.0"
   dependencies:


### PR DESCRIPTION
## Context 🤔 ☕ 

Internally, we are looking for ways to improve our Q&A engagement and give more visibility to the people who tend to help with both questions and answers.

Our initial idea is to create a component that can be used on the homepage and show who the users are with the best questions and answers, eventually we want to reward these people internally with some gifts ❤️ 

In order not to complicate the implementations, we thought of adding some simple aggregation endpoints and using them in a ranking.

We also find it interesting to have the data of the person who is logged into the backstage.

We have a small **sketch** of how we imagine this component.
![image](https://github.com/drodil/backstage-plugin-qeta/assets/20074620/20fee857-09bb-49a0-a4a9-87c4db9461db)

Response sample:
![image](https://github.com/drodil/backstage-plugin-qeta/assets/20074620/a977e286-c4b0-458c-bf10-f23a07a69c82)

Feedbacks are very welcome, this is just a first suggestion :)