### PR TITLE
fix(bug-stats-card): fix wrong path TopUpvotedCorrectAnswers

### DIFF
--- a/plugins/qeta/src/api/QetaClient.ts
+++ b/plugins/qeta/src/api/QetaClient.ts
@@ -514,7 +514,7 @@ export class QetaClient implements QetaApi {
     options: StatisticsRequestParameters,
   ): Promise<StatisticResponse> {
     const query = this.getQueryParameters(options.options).toString();
-    let url = `${await this.getBaseUrl()}/statistics/answers/top-correct-upvoted-users`;
+    let url = `${await this.getBaseUrl()}/statistics/questions/top-correct-upvoted-users`;
 
     if (query) {
       url += `?${query}`;


### PR DESCRIPTION
Fix the behavior that the tab of _Top Upvoted Questions_ was equal to _Top Upvoted Correct Answers_