### PR TITLE
fix(questions): returning fields on post question

### DIFF
--- a/plugins/qeta-backend/src/database/DatabaseQetaStore.ts
+++ b/plugins/qeta-backend/src/database/DatabaseQetaStore.ts
@@ -295,7 +295,8 @@ export class DatabaseQetaStore implements QetaStore {
         },
         ['id'],
       )
-      .into('questions');
+      .into('questions')
+      .returning(['id', 'author', 'title', 'content', 'created']);
 
     await Promise.all([
       this.addQuestionTags(questions[0].id, tags),


### PR DESCRIPTION
# Why

- Currently when created a new question is only returned the id field. Thus, when using event broker, the payload of the created question is sent uncompleted. 
Question object returned from `database.postQuestion`:
```
{
  id: 1,
  author: undefined,
  title: undefined,
  content: undefined,
  created: undefined,
  updated: undefined,
  updatedBy: undefined,
  score: 0,
  views: 0,
  answersCount: 0,
  correctAnswer: false,
  favorite: false,
  tags: [],
  answers: undefined,
  votes: undefined,
  entities: [],
  trend: 0,
  comments: undefined
}
```
# What

- Added the fields `id`, `author`, `title`, `content`, `created` to return when created a new question.