### PR TITLE
feat: when allowMetadataInput is enabled, accept created and user fields

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ git rebase upstream/main
 git checkout -b new-feature
 ```
 
-Make your changes, then ensure that `yarn lint` and `yarn test` still pass. If you're satisfied with your changes, push them to your fork.
+Make your changes, then ensure that `yarn lint`, `yarn tsc` and `yarn test` still pass. If you're satisfied with your changes, push them to your fork.
 
 Also remember to run database changes against a postgres instance. The instance can reside inside docker image or on local
 machine.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -45,6 +45,7 @@ qeta:
     # maxSizeImage: 2500000
     # allowedFilesTypes: ['image/png', 'image/jpg', 'image/jpeg', 'image/gif']
   allowAnonymous: true
+  allowMetadataInput: false
   entities:
     max: 2
   tags:

--- a/docs/config.md
+++ b/docs/config.md
@@ -5,6 +5,7 @@ The following configuration options are available for your app-config.yaml:
 ```yaml
 qeta:
   allowAnonymous: true
+  allowMetadataInput: false
   entities:
     kinds: ['Component']
     max: 3
@@ -23,6 +24,7 @@ qeta:
 The configuration values are:
 
 - allowAnonymous, boolean, allows anonymous users to post questions and answers. If enabled all users without authentication will be named after guest user. Required for local development.
+- allowMetadataInput, boolean, allows `created` and `user` fields to be passed when creating questions, answers, or comments. Useful if migrating information into the system. Default is `false`
 - entities.kinds, string array, what kind of catalog entities can be attached to a question. Default is ['Component']
 - entities.max, integer, maximum number of entities to attach to a question. Default is `3`
 - tags.allowCreation, boolean, determines whether it's possible to add new tags when creating question. Default is `true`

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -121,4 +121,4 @@ Then add it to your entity page:
 
 ## Importing content from another system
 
-You can use the backend API to import content via the question, answer, and comment endpoints. If you set `allowMetadataInput` to `true` in your config, you can also pass in the `created` and `user` fields to preserve this metadata from another system.
+You can use the backend API to import content via the question, answer, and comment endpoints. If you set `allowMetadataInput` to `true` in your config, you can also pass in the `created` and `user` fields in to preserve this metadata from another system. For POST requests, you can pass these as keys in the JSON payload. For GET requests, you can pass the username with a `x-qeta-user` header.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -118,3 +118,7 @@ Then add it to your entity page:
     <QetaContent />
 </EntityLayout.Route>,
 ```
+
+## Importing content from another system
+
+You can use the backend API to import content via the question, answer, and comment endpoints. If you set `allowMetadataInput` to `true` in your config, you can also pass in the `created` and `user` fields to preserve this metadata from another system.

--- a/plugins/qeta-backend/configSchema.d.ts
+++ b/plugins/qeta-backend/configSchema.d.ts
@@ -7,6 +7,12 @@ export interface Config {
      */
     allowAnonymous?: boolean;
     /**
+     * Allow author and created fields to be specified
+     *
+     * @visibility backend
+     */
+    allowMetadataInput?: boolean;
+    /**
      * Entities configuration for questions.
      *
      * @visibility frontend

--- a/plugins/qeta-backend/src/database/DatabaseQetaStore.test.ts
+++ b/plugins/qeta-backend/src/database/DatabaseQetaStore.test.ts
@@ -129,7 +129,12 @@ describe.each(databases.eachSupportedId())(
       it('should be able to answer question', async () => {
         const id = await insertQuestion(question);
 
-        const ans = await storage.answerQuestion('user', id, 'answer');
+        const ans = await storage.answerQuestion(
+          'user',
+          id,
+          'answer',
+          new Date(),
+        );
         expect(ans).toBeDefined();
         expect(ans?.content).toEqual('answer');
         expect(ans?.questionId).toEqual(id);
@@ -138,6 +143,7 @@ describe.each(databases.eachSupportedId())(
           ans?.id ?? 0,
           'user:default/user',
           'this is comment',
+          new Date(),
         );
         expect(ans2?.comments?.length).toEqual(1);
       });
@@ -179,6 +185,7 @@ describe.each(databases.eachSupportedId())(
           'user1',
           'title',
           'content',
+          new Date(),
           ['java', 'xml', ''],
           ['component:default/comp1', 'component:default/comp2'],
         );
@@ -186,6 +193,7 @@ describe.each(databases.eachSupportedId())(
           'user2',
           'title2',
           'content2',
+          new Date(),
           ['java', 'mysql'],
           ['component:default/comp2', 'component:default/comp3'],
         );
@@ -210,6 +218,7 @@ describe.each(databases.eachSupportedId())(
           'user1',
           'title',
           'content',
+          new Date(),
           ['java', 'xml', ''],
           ['component:default/comp1', 'component:default/comp2'],
         );
@@ -217,6 +226,7 @@ describe.each(databases.eachSupportedId())(
           'user2',
           'title2',
           'content2',
+          new Date(),
           ['java', 'mysql'],
           ['component:default/comp2', 'component:default/comp3'],
         );
@@ -248,6 +258,7 @@ describe.each(databases.eachSupportedId())(
           'user1',
           'title',
           'content',
+          new Date(),
           ['java', 'xml', ''],
           [
             'component:default/comp1',
@@ -260,6 +271,7 @@ describe.each(databases.eachSupportedId())(
           'user2',
           'title2',
           'content2',
+          new Date(),
           ['java', 'mysql'],
           ['component:default/comp2', 'component:default/comp3'],
         );
@@ -280,6 +292,7 @@ describe.each(databases.eachSupportedId())(
           id1.id,
           'user:default/user',
           'this is comment',
+          new Date(),
         );
         expect(ret3?.comments?.length).toEqual(1);
       });
@@ -289,6 +302,7 @@ describe.each(databases.eachSupportedId())(
           'user1',
           'title',
           'content',
+          new Date(),
           ['java', 'xml', ''],
           [
             'component:default/comp1',
@@ -323,6 +337,7 @@ describe.each(databases.eachSupportedId())(
           'user1',
           'title',
           'content',
+          new Date(),
           ['java', 'xml', ''],
           [
             'component:default/comp1',
@@ -345,7 +360,7 @@ describe.each(databases.eachSupportedId())(
       });
 
       it('should delete question', async () => {
-        const id1 = await storage.postQuestion('user1', 'title', 'content');
+        const id1 = await storage.postQuestion('user1', 'title', 'content', new Date());
         let ret1 = await storage.getQuestion('user', id1.id);
         expect(ret1?.title).toEqual('title');
 

--- a/plugins/qeta-backend/src/database/DatabaseQetaStore.test.ts
+++ b/plugins/qeta-backend/src/database/DatabaseQetaStore.test.ts
@@ -360,7 +360,12 @@ describe.each(databases.eachSupportedId())(
       });
 
       it('should delete question', async () => {
-        const id1 = await storage.postQuestion('user1', 'title', 'content', new Date());
+        const id1 = await storage.postQuestion(
+          'user1',
+          'title',
+          'content',
+          new Date(),
+        );
         let ret1 = await storage.getQuestion('user', id1.id);
         expect(ret1?.title).toEqual('title');
 

--- a/plugins/qeta-backend/src/database/DatabaseQetaStore.ts
+++ b/plugins/qeta-backend/src/database/DatabaseQetaStore.ts
@@ -281,6 +281,7 @@ export class DatabaseQetaStore implements QetaStore {
     user_ref: string,
     title: string,
     content: string,
+    created: Date,
     tags?: string[],
     entities?: string[],
     images?: number[],
@@ -291,7 +292,7 @@ export class DatabaseQetaStore implements QetaStore {
           author: user_ref,
           title,
           content,
-          created: new Date(),
+          created,
         },
         ['id'],
       )
@@ -316,12 +317,13 @@ export class DatabaseQetaStore implements QetaStore {
     question_id: number,
     user_ref: string,
     content: string,
+    created: Date,
   ): Promise<MaybeQuestion> {
     await this.db
       .insert({
         author: user_ref,
         content,
-        created: new Date(),
+        created,
         questionId: question_id,
       })
       .into('question_comments');
@@ -346,12 +348,13 @@ export class DatabaseQetaStore implements QetaStore {
     answer_id: number,
     user_ref: string,
     content: string,
+    created: Date,
   ): Promise<MaybeAnswer> {
     await this.db
       .insert({
         author: user_ref,
         content,
-        created: new Date(),
+        created,
         answerId: answer_id,
       })
       .into('answer_comments');
@@ -414,6 +417,7 @@ export class DatabaseQetaStore implements QetaStore {
     user_ref: string,
     questionId: number,
     answer: string,
+    created: Date,
     images?: number[],
   ): Promise<MaybeAnswer> {
     const answers = await this.db
@@ -422,7 +426,7 @@ export class DatabaseQetaStore implements QetaStore {
         author: user_ref,
         content: answer,
         correct: false,
-        created: new Date(),
+        created,
       })
       .into('answers')
       .returning('id');

--- a/plugins/qeta-backend/src/database/QetaStore.ts
+++ b/plugins/qeta-backend/src/database/QetaStore.ts
@@ -168,6 +168,7 @@ export interface QetaStore {
     user_ref: string,
     title: string,
     content: string,
+    created: Date,
     tags?: string[],
     components?: string[],
     images?: number[],
@@ -183,6 +184,7 @@ export interface QetaStore {
     question_id: number,
     user_ref: string,
     content: string,
+    created: Date,
   ): Promise<MaybeQuestion>;
 
   /**
@@ -233,6 +235,7 @@ export interface QetaStore {
     user_ref: string,
     questionId: number,
     answer: string,
+    created: Date,
     images?: number[],
   ): Promise<MaybeAnswer>;
 
@@ -246,6 +249,7 @@ export interface QetaStore {
     answer_id: number,
     user_ref: string,
     content: string,
+    created: Date,
   ): Promise<MaybeAnswer>;
 
   /**

--- a/plugins/qeta-backend/src/service/router.test.ts
+++ b/plugins/qeta-backend/src/service/router.test.ts
@@ -683,6 +683,24 @@ describe('createRouter', () => {
       expect(response.status).toEqual(404);
     });
 
+    it('allows user to be specified as a header if allowMetadataInput is true', async () => {
+      qetaStore.markAnswerCorrect.mockResolvedValue(false);
+      const config = ConfigReader.fromConfigs([
+        { context: 'qeta', data: { qeta: { allowMetadataInput: true } } },
+      ]);
+      app = await buildApp(config);
+
+      const response = await request(app)
+        .get('/questions/1/answers/2/correct')
+        .set('x-qeta-user', 'another-user');
+      expect(qetaStore.markAnswerCorrect).toHaveBeenCalledWith(
+        'another-user',
+        1,
+        2,
+      );
+      expect(response.status).toEqual(404);
+    });
+
     it('unauthorized', async () => {
       getIdentityMock.mockResolvedValue(undefined);
       const response = await request(app).get('/questions/1/answers/2/correct');

--- a/plugins/qeta-backend/src/service/routes/answers.ts
+++ b/plugins/qeta-backend/src/service/routes/answers.ts
@@ -1,7 +1,12 @@
 import { RouterOptions } from '../router';
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
-import { checkPermissions, getUsername, mapAdditionalFields } from '../util';
+import {
+  checkPermissions,
+  getUsername,
+  getCreated,
+  mapAdditionalFields,
+} from '../util';
 import { CommentSchema, PostAnswerSchema } from '../types';
 import { Request, Router } from 'express';
 import {
@@ -29,12 +34,14 @@ export const answersRoutes = (router: Router, options: RouterOptions) => {
     }
 
     const username = await getUsername(request, options);
+    const created = await getCreated(request, options);
     const questionId = Number.parseInt(request.params.id, 10);
     // Act
     const answer = await database.answerQuestion(
       username,
       questionId,
       request.body.answer,
+      created,
       request.body.images,
     );
 
@@ -105,12 +112,14 @@ export const answersRoutes = (router: Router, options: RouterOptions) => {
       }
 
       const username = await getUsername(request, options);
+      const created = await getCreated(request, options);
       const answerId = Number.parseInt(request.params.answerId, 10);
       // Act
       const answer = await database.commentAnswer(
         answerId,
         username,
         request.body.content,
+        created,
       );
 
       if (!answer) {

--- a/plugins/qeta-backend/src/service/routes/questions.ts
+++ b/plugins/qeta-backend/src/service/routes/questions.ts
@@ -1,6 +1,11 @@
 import { RouterOptions } from '../router';
 import { QuestionsOptions } from '../../database/QetaStore';
-import { checkPermissions, getUsername, mapAdditionalFields } from '../util';
+import {
+  checkPermissions,
+  getUsername,
+  getCreated,
+  mapAdditionalFields,
+} from '../util';
 import Ajv from 'ajv';
 import { Request, Router } from 'express';
 import {
@@ -104,6 +109,7 @@ export const questionsRoutes = (router: Router, options: RouterOptions) => {
     // Validation
     // Act
     const username = await getUsername(request, options);
+    const created = await getCreated(request, options);
     await checkPermissions(request, qetaReadPermission, options);
     const validateRequestBody = ajv.compile(CommentSchema);
     if (!validateRequestBody(request.body)) {
@@ -116,6 +122,7 @@ export const questionsRoutes = (router: Router, options: RouterOptions) => {
       Number.parseInt(request.params.id, 10),
       username,
       request.body.content,
+      created,
     );
 
     if (question === null) {
@@ -210,11 +217,14 @@ export const questionsRoutes = (router: Router, options: RouterOptions) => {
     const tags = getTags(request);
     const entities = getEntities(request);
     const username = await getUsername(request, options);
+    const created = await getCreated(request, options);
+
     // Act
     const question = await database.postQuestion(
       username,
       request.body.title,
       request.body.content,
+      created,
       tags,
       entities,
       request.body.images,

--- a/plugins/qeta-backend/src/service/types.ts
+++ b/plugins/qeta-backend/src/service/types.ts
@@ -26,6 +26,8 @@ export interface PostQuestion {
   tags?: string[];
   entities?: string[];
   images?: number[];
+  user?: string;
+  created?: string;
 }
 
 export const QuestionsQuerySchema: JSONSchemaType<QuestionsQuery> = {
@@ -65,6 +67,8 @@ export const PostQuestionSchema: JSONSchemaType<PostQuestion> = {
     tags: { type: 'array', items: { type: 'string' }, nullable: true },
     entities: { type: 'array', items: { type: 'string' }, nullable: true },
     images: { type: 'array', items: { type: 'integer' }, nullable: true },
+    user: { type: 'string', minLength: 1, nullable: true },
+    created: { type: 'string', minLength: 1, nullable: true },
   },
   required: ['title', 'content'],
   additionalProperties: false,
@@ -73,6 +77,8 @@ export const PostQuestionSchema: JSONSchemaType<PostQuestion> = {
 export interface AnswerQuestion {
   answer: string;
   images?: number[];
+  user?: string;
+  created?: string;
 }
 
 export const PostAnswerSchema: JSONSchemaType<AnswerQuestion> = {
@@ -80,6 +86,8 @@ export const PostAnswerSchema: JSONSchemaType<AnswerQuestion> = {
   properties: {
     answer: { type: 'string', minLength: 1 },
     images: { type: 'array', items: { type: 'integer' }, nullable: true },
+    user: { type: 'string', minLength: 1, nullable: true },
+    created: { type: 'string', minLength: 1, nullable: true },
   },
   required: ['answer'],
   additionalProperties: false,
@@ -87,12 +95,16 @@ export const PostAnswerSchema: JSONSchemaType<AnswerQuestion> = {
 
 export interface Comment {
   content: string;
+  user?: string;
+  created?: string;
 }
 
 export const CommentSchema: JSONSchemaType<Comment> = {
   type: 'object',
   properties: {
     content: { type: 'string', minLength: 1 },
+    user: { type: 'string', minLength: 1, nullable: true },
+    created: { type: 'string', minLength: 1, nullable: true },
   },
   required: ['content'],
   additionalProperties: false,

--- a/plugins/qeta-backend/src/service/util.ts
+++ b/plugins/qeta-backend/src/service/util.ts
@@ -18,13 +18,35 @@ export const getUsername = async (
   const allowAnonymous = options.config.getOptionalBoolean(
     'qeta.allowAnonymous',
   );
+  const allowMetadataInput = options.config.getOptionalBoolean(
+    'qeta.allowMetadataInput',
+  );
+
   if (!user) {
     if (allowAnonymous) {
       return 'user:default/guest';
     }
     throw new AuthenticationError(`Missing token in 'authorization' header`);
+  } else if (allowMetadataInput && req.body.user) {
+    return req.body.user;
+  } else {
+    return user.identity.userEntityRef;
   }
-  return user.identity.userEntityRef;
+};
+
+export const getCreated = async (
+  req: Request<unknown>,
+  options: RouterOptions,
+): Promise<Date> => {
+  const allowMetadataInput = options.config.getOptionalBoolean(
+    'qeta.allowMetadataInput',
+  );
+
+  if (allowMetadataInput && req.body.created) {
+    return new Date(req.body.created);
+  }
+
+  return new Date();
 };
 
 export const checkPermissions = async (

--- a/plugins/qeta-backend/src/service/util.ts
+++ b/plugins/qeta-backend/src/service/util.ts
@@ -29,6 +29,8 @@ export const getUsername = async (
     throw new AuthenticationError(`Missing token in 'authorization' header`);
   } else if (allowMetadataInput && req.body.user) {
     return req.body.user;
+  } else if (allowMetadataInput && req.get('x-qeta-user')) {
+    return req.get('x-qeta-user')!;
   } else {
     return user.identity.userEntityRef;
   }


### PR DESCRIPTION
The backend APIs work nicely when importing content.  The only hitch is that you can't import content with a creation time or attribution, so all Q&A entries appear as if they were created today by the user who ran the load.

This PR adds an `allowMetadataInput` config flag that, when enabled, allows `created` and `author` fields to be passed along in the POST request to override the default handling.  Normally this should be flagged false except during initial import or loading.

One major area of change is that previously the DatabaseQetaStore always used the current time as the `created` value. This PR requires that a `created` value is explicitly passed into persistence functions.  This PR also adds a `getCreated` function to the utils in parallel to `getUsername` that either accepts these fields from input or uses the current date as a default.

Curious to get your thoughts!