### PR TITLE
feat: use entity title on entity ask page

### DIFF
--- a/plugins/qeta/src/components/AskPage/AskPage.tsx
+++ b/plugins/qeta/src/components/AskPage/AskPage.tsx
@@ -4,15 +4,25 @@ import React from 'react';
 
 import { AskForm } from '../AskForm/AskForm';
 import { useParams } from 'react-router-dom';
+import { formatEntityName } from '../../utils/utils';
 import { BackToQuestionsButton } from '../Buttons/BackToQuestionsButton';
 
 export const AskPage = () => {
   const { id } = useParams();
   const params = new URLSearchParams(window.location.search);
   const entity = params.get('entity') ?? undefined;
+  let title;
+  if (id) {
+    title = 'Edit question';
+  } else if (entity) {
+    title = `Ask a question about ${formatEntityName(entity)}`;
+  } else {
+    title = 'Ask question';
+  }
+
   return (
     <Content className="qetaAskPage">
-      <ContentHeader title={id ? 'Edit question' : 'Ask question'}>
+      <ContentHeader title={title}>
         <BackToQuestionsButton />
       </ContentHeader>
       <Grid container spacing={3} direction="column">


### PR DESCRIPTION
This PR adjusts the entity ask page to include the entity's name, so that it's clear to the user what they are asking a question about (and why the entity picker does not appear). This mirrors the logic on the question list page.

Here's what this looks like:
![image](https://github.com/drodil/backstage-plugin-qeta/assets/35356/b459fe68-3d26-4f8f-a0d6-1ba32f995e3f)
