### PR TITLE
feat: searching resets the page

### DIFF
--- a/plugins/qeta/src/components/QuestionsContainer/QuestionsContainer.tsx
+++ b/plugins/qeta/src/components/QuestionsContainer/QuestionsContainer.tsx
@@ -74,6 +74,7 @@ export const QuestionsContainer = (props: QuestionsContainerProps) => {
   };
 
   const onSearchQueryChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    onPageChange(1);
     setSearchQuery(event.target.value);
   };
 


### PR DESCRIPTION
### What
solves issue https://github.com/drodil/backstage-plugin-qeta/issues/112 by reset page parameter like when we filter something

### How
I used the same function used in filters onPageChange(1)

### Prints & Tests
I've created 6 questions and I moved to page 2
![Screenshot from 2024-01-07 17-25-51](https://github.com/drodil/backstage-plugin-qeta/assets/7469400/96a7a7bc-a6eb-4d98-925d-1c6414dd22ab)

Then I have search for "teste 5" (and now the page returned to page 1)
![Screenshot from 2024-01-07 17-25-28](https://github.com/drodil/backstage-plugin-qeta/assets/7469400/f9466a68-634e-45e5-8dc4-418292f7d26a)

