### PR TITLE
feat: add analytics events to search

### DIFF
--- a/plugins/qeta/src/components/QuestionsContainer/QuestionsContainer.tsx
+++ b/plugins/qeta/src/components/QuestionsContainer/QuestionsContainer.tsx
@@ -16,6 +16,7 @@ import FilterList from '@material-ui/icons/FilterList';
 import { useSearchParams } from 'react-router-dom';
 import { AskQuestionButton } from '../Buttons/AskQuestionButton';
 import { EntityRefLink } from '@backstage/plugin-catalog-react';
+import { useAnalytics } from '@backstage/core-plugin-api';
 
 export interface QuestionsContainerProps {
   tags?: string[];
@@ -40,6 +41,7 @@ export const QuestionsContainer = (props: QuestionsContainerProps) => {
     showAskButton,
     showNoQuestionsBtn,
   } = props;
+  const analytics = useAnalytics();
   const [page, setPage] = React.useState(1);
   const [questionsPerPage, setQuestionsPerPage] = React.useState(10);
   const [showFilterPanel, setShowFilterPanel] = React.useState(false);
@@ -87,6 +89,7 @@ export const QuestionsContainer = (props: QuestionsContainerProps) => {
 
   const onSearchQueryChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     onPageChange(1);
+    analytics.captureEvent('qeta-search', event.target.value ?? '');
     setSearchQuery(event.target.value);
   };
 

--- a/plugins/qeta/src/components/QuestionsContainer/QuestionsContainer.tsx
+++ b/plugins/qeta/src/components/QuestionsContainer/QuestionsContainer.tsx
@@ -89,7 +89,7 @@ export const QuestionsContainer = (props: QuestionsContainerProps) => {
 
   const onSearchQueryChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     onPageChange(1);
-    if(event.target.value) {
+    if (event.target.value) {
       analytics.captureEvent('qeta_search', event.target.value);
     }
     setSearchQuery(event.target.value);

--- a/plugins/qeta/src/components/QuestionsContainer/QuestionsContainer.tsx
+++ b/plugins/qeta/src/components/QuestionsContainer/QuestionsContainer.tsx
@@ -89,7 +89,7 @@ export const QuestionsContainer = (props: QuestionsContainerProps) => {
 
   const onSearchQueryChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     onPageChange(1);
-    analytics.captureEvent('qeta-search', event.target.value ?? '');
+    analytics.captureEvent('search', event.target.value ?? '');
     setSearchQuery(event.target.value);
   };
 

--- a/plugins/qeta/src/components/QuestionsContainer/QuestionsContainer.tsx
+++ b/plugins/qeta/src/components/QuestionsContainer/QuestionsContainer.tsx
@@ -89,7 +89,9 @@ export const QuestionsContainer = (props: QuestionsContainerProps) => {
 
   const onSearchQueryChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     onPageChange(1);
-    analytics.captureEvent('search', event.target.value ?? '');
+    if(event.target.value) {
+      analytics.captureEvent('qeta_search', event.target.value);
+    }
     setSearchQuery(event.target.value);
   };
 


### PR DESCRIPTION
## What & Why

We would like to have more data on the qeta search so that we can better understand how people are using our engineering.

I was inspired by the use of the other analytics calls in the plugin.