### PR TITLE
fix: selected correct answer color

### DIFF
--- a/plugins/qeta/src/components/QuestionPage/VoteButtons.tsx
+++ b/plugins/qeta/src/components/QuestionPage/VoteButtons.tsx
@@ -5,8 +5,11 @@ import {
 import {
   Box,
   IconButton,
+  Theme,
   Tooltip,
   Typography,
+  createStyles,
+  makeStyles,
   useTheme,
 } from '@material-ui/core';
 import ArrowDownward from '@material-ui/icons/ArrowDownward';
@@ -15,6 +18,17 @@ import Check from '@material-ui/icons/Check';
 import React from 'react';
 import { useAnalytics, useApi } from '@backstage/core-plugin-api';
 import { qetaApiRef } from '../../api';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    qetaCorrectAnswerSelected: {
+      color: theme.palette.success.main,
+    },
+    qetaCorrectAnswer: {
+      color: theme.palette.grey[500],
+    },
+  }),
+);
 
 export const VoteButtons = (props: {
   entity: QuestionResponse | AnswerResponse;
@@ -32,6 +46,7 @@ export const VoteButtons = (props: {
   const theme = useTheme();
   const isQuestion = 'title' in entity;
   const own = props.entity.own ?? false;
+  const classes = useStyles();
 
   const voteUp = () => {
     if (isQuestion) {
@@ -155,14 +170,9 @@ export const VoteButtons = (props: {
                   <Check
                     className={
                       correct
-                        ? 'qetaCorrectAnswerSelected'
-                        : 'qetaCorrectAnswer'
+                        ? classes.qetaCorrectAnswerSelected
+                        : classes.qetaCorrectAnswer
                     }
-                    style={{
-                      color: correct
-                        ? `${theme.palette.success.main} !important`
-                        : undefined,
-                    }}
                   />
                 </IconButton>
               </span>

--- a/plugins/qeta/src/components/QuestionPage/VoteButtons.tsx
+++ b/plugins/qeta/src/components/QuestionPage/VoteButtons.tsx
@@ -10,7 +10,6 @@ import {
   Typography,
   createStyles,
   makeStyles,
-  useTheme,
 } from '@material-ui/core';
 import ArrowDownward from '@material-ui/icons/ArrowDownward';
 import ArrowUpward from '@material-ui/icons/ArrowUpward';
@@ -43,7 +42,7 @@ export const VoteButtons = (props: {
     props.entity,
   );
   const qetaApi = useApi(qetaApiRef);
-  const theme = useTheme();
+
   const isQuestion = 'title' in entity;
   const own = props.entity.own ?? false;
   const classes = useStyles();


### PR DESCRIPTION
The check icon when the correct answer is not being colored, should be styled as green.

**Before:**
![image](https://github.com/drodil/backstage-plugin-qeta/assets/19962665/7e0dcee6-e6d2-4125-815e-a907c2143349)

**After**
<img width="1341" alt="image" src="https://github.com/drodil/backstage-plugin-qeta/assets/19962665/3509e55d-55db-4e40-8bd1-8715552fe06b">


