### PR TITLE
fix: add user prefix to entityRef in UserLink

### DIFF
--- a/plugins/qeta/src/components/Links/Links.tsx
+++ b/plugins/qeta/src/components/Links/Links.tsx
@@ -15,8 +15,12 @@ export const UserLink = (props: {
 }) => {
   const { entityRef, linkProps } = props;
   const userRoute = useRouteRef(userRouteRef);
-  const { primaryTitle: userName } = useEntityPresentation(entityRef);
-
+  const { primaryTitle: userName } = useEntityPresentation(
+    entityRef.startsWith('user:') ? entityRef : `user:${entityRef}`,
+  );
+  if (entityRef === 'anonymous') {
+    return <>Anonymous</>;
+  }
   return (
     <Link to={`${userRoute()}/${entityRef}`} {...linkProps}>
       {userName}
@@ -29,11 +33,6 @@ export const AuthorLink = (props: {
   linkProps?: LinkProps;
 }) => {
   const { entity, linkProps } = props;
-
-  if (entity.author === 'anonymous') {
-    return <>Anonymous</>;
-  }
-
   return <UserLink entityRef={entity.author} linkProps={linkProps} />;
 };
 

--- a/plugins/qeta/src/components/Links/Links.tsx
+++ b/plugins/qeta/src/components/Links/Links.tsx
@@ -16,9 +16,7 @@ export const UserLink = (props: {
   const { entityRef, linkProps } = props;
   const userRoute = useRouteRef(userRouteRef);
   const { primaryTitle: userName } = useEntityPresentation(entityRef);
-  if (entityRef === 'anonymous') {
-    return <>Anonymous</>;
-  }
+
   return (
     <Link to={`${userRoute()}/${entityRef}`} {...linkProps}>
       {userName}
@@ -31,6 +29,11 @@ export const AuthorLink = (props: {
   linkProps?: LinkProps;
 }) => {
   const { entity, linkProps } = props;
+
+  if (entity.author === 'anonymous') {
+    return <>Anonymous</>;
+  }
+
   return <UserLink entityRef={entity.author} linkProps={linkProps} />;
 };
 


### PR DESCRIPTION
Possible fix for issue: https://github.com/drodil/backstage-plugin-qeta/issues/152.

The if-statement in UserLink won't be executed at the moment if the entityRef is actually 'anonymous' as it will then always crash when executing `useEntityPresentation`.

A possible fix could be to move the check to the `AuthorLink` component as this PR suggests.
Not sure if it would need to be added in more places, like `UpdatedByLink` for example.