### PR TITLE
fix: Fixed issue #152, entity filter disappear on select and selected entity showing twice in dropdown

### DIFF
--- a/plugins/qeta/src/components/QuestionsContainer/FilterPanel.tsx
+++ b/plugins/qeta/src/components/QuestionsContainer/FilterPanel.tsx
@@ -216,8 +216,7 @@ export const FilterPanel = (props: FilterPanelProps) => {
               <FormLabel id="qeta-filter-entity">Filters</FormLabel>
               {showEntityFilter &&
                 availableEntities &&
-                availableEntities.length > 0 &&
-                (!filters.entity || selectedEntity) && (
+                availableEntities.length > 0 && (
                   <Autocomplete
                     multiple={false}
                     className="qetaEntityFilter"

--- a/plugins/qeta/src/components/QuestionsContainer/FilterPanel.tsx
+++ b/plugins/qeta/src/components/QuestionsContainer/FilterPanel.tsx
@@ -89,13 +89,22 @@ export const FilterPanel = (props: FilterPanelProps) => {
   }, [tags, filters.tags]);
 
   useEffect(() => {
-    if (
-      (filters.entity || (refs && refs?.length > 0)) &&
-      !Array.isArray(filters.entity)
-    ) {
+    const entityRefs: string[] = [];
+    if (filters.entity && !Array.isArray(filters.entity)) {
+      entityRefs.push(filters.entity);
+    }
+    if (refs && refs?.length > 0) {
+      refs?.forEach(ref => {
+        // ignore currently selected entity if exist in refs
+        if (ref.entityRef !== filters.entity) {
+          entityRefs.push(ref.entityRef);
+        }
+      });
+    }
+    if (entityRefs.length > 0) {
       catalogApi
         .getEntitiesByRefs({
-          entityRefs: [...(refs ?? []).map(e => e.entityRef), filters.entity],
+          entityRefs,
           fields: [
             'kind',
             'metadata.name',

--- a/plugins/qeta/src/components/QuestionsContainer/QuestionsContainer.tsx
+++ b/plugins/qeta/src/components/QuestionsContainer/QuestionsContainer.tsx
@@ -252,11 +252,7 @@ export const QuestionsContainer = (props: QuestionsContainerProps) => {
       </Grid>
       {(showFilters ?? true) && (
         <Collapse in={showFilterPanel}>
-          <FilterPanel
-            onChange={onFilterChange}
-            filters={filters}
-            showEntityFilter={!entity}
-          />
+          <FilterPanel onChange={onFilterChange} filters={filters} />
         </Collapse>
       )}
 


### PR DESCRIPTION
Removed showEntityFilter value setting based on entity query parameter and removing duplicate entity ref value from available entities list.

![qeta_fix_issue_#154_fixed](https://github.com/drodil/backstage-plugin-qeta/assets/138849700/983ab7cd-891a-49fc-91a2-68593b1ffa07)
