### PR TITLE
fix: image download broken after migrate to new backend system with default auth policy

### DIFF
--- a/plugins/qeta-backend/src/plugin.ts
+++ b/plugins/qeta-backend/src/plugin.ts
@@ -62,6 +62,11 @@ export const qetaPlugin = createBackendPlugin({
             notifications,
           }),
         );
+        // Allowing attachments download
+        httpRouter.addAuthPolicy({
+          allow: 'unauthenticated',
+          path: '/attachments',
+        });
       },
     });
   },


### PR DESCRIPTION
Fixed issue #157
Tested preview with uploaded image:

![image](https://github.com/drodil/backstage-plugin-qeta/assets/138849700/9565ddfe-1950-49d9-9145-116710bfff61)

Test question details page:

![image](https://github.com/drodil/backstage-plugin-qeta/assets/138849700/6a023c2e-c0dd-4f14-8309-5dfd029db1f0)

