### PR TITLE
Add Azure Blob Storage as a storage engine for attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,4 @@ dist
 !**/.yarn/versions
 
 dist-types/
+app-config.local.yaml

--- a/plugins/qeta-backend/configSchema.d.ts
+++ b/plugins/qeta-backend/configSchema.d.ts
@@ -79,7 +79,7 @@ export interface Config {
      * @visibility backend
      */
     storage?: {
-      type?: 'database' | 'filesystem' | 's3';
+      type?: 'database' | 'filesystem' | 's3' | 'azure';
       folder?: string;
       maxSizeImage?: number;
       allowedMimeTypes?: string[];
@@ -88,6 +88,9 @@ export interface Config {
       secretAccessKey?: string;
       region?: string;
       sessionToken?: string;
+      blobStorageAccountName?: string;
+      blobStorageConnectionString?: string;
+      blobStorageContainer?: string;
     };
     /**
      * Stats config

--- a/plugins/qeta-backend/package.json
+++ b/plugins/qeta-backend/package.json
@@ -48,6 +48,8 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.540.0",
+    "@azure/identity": "^4.5.0",
+    "@azure/storage-blob": "^12.26.0",
     "@backstage/backend-defaults": "backstage:^",
     "@backstage/backend-plugin-api": "backstage:^",
     "@backstage/catalog-client": "backstage:^",

--- a/plugins/qeta-backend/src/service/routes/attachments.ts
+++ b/plugins/qeta-backend/src/service/routes/attachments.ts
@@ -4,6 +4,7 @@ import multiparty from 'multiparty';
 import FilesystemStoreEngine from '../upload/filesystem';
 import DatabaseStoreEngine from '../upload/database';
 import S3StoreEngine from '../upload/s3';
+import AzureBlobStorageEngine from '../upload/azureBlobStorage';
 import fs from 'fs';
 import FileType from 'file-type';
 import { File, RouteOptions } from '../types';
@@ -43,6 +44,7 @@ export const attachmentsRoutes = (router: Router, options: RouteOptions) => {
     const fileSystemEngine = FilesystemStoreEngine(options);
     const databaseEngine = DatabaseStoreEngine(options);
     const s3Engine = S3StoreEngine(options);
+    const azureBlobStorageEngine = AzureBlobStorageEngine(options);
 
     form.parse(request, async (err, _fields, files) => {
       if (err) {
@@ -94,6 +96,9 @@ export const attachmentsRoutes = (router: Router, options: RouteOptions) => {
       };
 
       switch (storageType) {
+        case 'azure':
+          attachment = await azureBlobStorageEngine.handleFile(file, opts);
+          break;
         case 's3':
           attachment = await s3Engine.handleFile(file, opts);
           break;

--- a/plugins/qeta-backend/src/service/upload/attachmentStorageEngine.ts
+++ b/plugins/qeta-backend/src/service/upload/attachmentStorageEngine.ts
@@ -12,4 +12,5 @@ export type AttachmentStorageEngineOptions = {
 export interface AttachmentStorageEngine {
     handleFile: (file: File, options?: { postId?: number; answerId?: number; collectionId?: number }) => Promise<Attachment>;
     getAttachmentBuffer: (attachment: Attachment) => Promise<Buffer | undefined>;
+    deleteAttachment(attachment: Attachment): Promise<void>;
 }

--- a/plugins/qeta-backend/src/service/upload/attachmentStorageEngine.ts
+++ b/plugins/qeta-backend/src/service/upload/attachmentStorageEngine.ts
@@ -1,6 +1,15 @@
 import { Attachment } from '@drodil/backstage-plugin-qeta-common';
 import { File } from '../types';
+import { Config } from '@backstage/config/index';
+import { QetaStore } from '../../database/QetaStore';
+
+export type AttachmentStorageEngineOptions = {
+    config: Config;
+    database: QetaStore;
+};
+  
 
 export interface AttachmentStorageEngine {
     handleFile: (file: File, options?: { postId?: number; answerId?: number; collectionId?: number }) => Promise<Attachment>;
+    getAttachmentBuffer: (attachment: Attachment) => Promise<Buffer | undefined>;
 }

--- a/plugins/qeta-backend/src/service/upload/attachmentStorageEngine.ts
+++ b/plugins/qeta-backend/src/service/upload/attachmentStorageEngine.ts
@@ -1,0 +1,6 @@
+import { Attachment } from '@drodil/backstage-plugin-qeta-common';
+import { File } from '../types';
+
+export interface AttachmentStorageEngine {
+    handleFile: (file: File, options?: { postId?: number; answerId?: number; collectionId?: number }) => Promise<Attachment>;
+}

--- a/plugins/qeta-backend/src/service/upload/azureBlobStorage.ts
+++ b/plugins/qeta-backend/src/service/upload/azureBlobStorage.ts
@@ -5,12 +5,7 @@ import { QetaStore } from '../../database/QetaStore';
 import { Attachment } from '@drodil/backstage-plugin-qeta-common';
 import { File } from '../types';
 import { getAzureBlobServiceClient } from '../util';
-import { AttachmentStorageEngine } from './attachmentStorageEngine';
-
-type Options = {
-  config: Config;
-  database: QetaStore;
-};
+import { AttachmentStorageEngine, AttachmentStorageEngineOptions } from './attachmentStorageEngine';
 
 class AzureBlobStorageEngine implements AttachmentStorageEngine {
   config: Config;
@@ -19,7 +14,7 @@ class AzureBlobStorageEngine implements AttachmentStorageEngine {
   qetaUrl: string;
   container: string;
 
-  constructor(opts: Options) {
+  constructor(opts: AttachmentStorageEngineOptions) {
     this.config = opts.config;
     this.database = opts.database;
     this.backendBaseUrl = this.config.getString('backend.baseUrl');
@@ -57,8 +52,15 @@ class AzureBlobStorageEngine implements AttachmentStorageEngine {
       ...options,
     });
   };
+
+  getAttachmentBuffer = async (attachment: Attachment) => {
+    const client = getAzureBlobServiceClient(this.config);
+    const container = client.getContainerClient(this.container);
+    const blob = container.getBlockBlobClient(attachment.path);
+    return blob.downloadToBuffer();
+  }
 }
 
-export default (opts: Options) => {
+export default (opts: AttachmentStorageEngineOptions) => {
   return new AzureBlobStorageEngine(opts);
 };

--- a/plugins/qeta-backend/src/service/upload/azureBlobStorage.ts
+++ b/plugins/qeta-backend/src/service/upload/azureBlobStorage.ts
@@ -59,6 +59,13 @@ class AzureBlobStorageEngine implements AttachmentStorageEngine {
     const blob = container.getBlockBlobClient(attachment.path);
     return blob.downloadToBuffer();
   }
+
+  deleteAttachment = async (attachment: Attachment) => {
+    const client = getAzureBlobServiceClient(this.config);
+    const container = client.getContainerClient(this.container);
+    const blob = container.getBlockBlobClient(attachment.path);
+    await blob.delete();
+  }
 }
 
 export default (opts: AttachmentStorageEngineOptions) => {

--- a/plugins/qeta-backend/src/service/upload/azureBlobStorage.ts
+++ b/plugins/qeta-backend/src/service/upload/azureBlobStorage.ts
@@ -1,0 +1,63 @@
+import * as fs from 'fs';
+import { v4 as uuidv4 } from 'uuid';
+import { Config } from '@backstage/config';
+import { QetaStore } from '../../database/QetaStore';
+import { Attachment } from '@drodil/backstage-plugin-qeta-common';
+import { File } from '../types';
+import { getAzureBlobServiceClient } from '../util';
+
+type Options = {
+  config: Config;
+  database: QetaStore;
+};
+
+class AzureBlobStorageEngine {
+  config: Config;
+  database: QetaStore;
+  backendBaseUrl: string;
+  qetaUrl: string;
+  container: string;
+
+  constructor(opts: Options) {
+    this.config = opts.config;
+    this.database = opts.database;
+    this.backendBaseUrl = this.config.getString('backend.baseUrl');
+    this.qetaUrl = `${this.backendBaseUrl}/api/qeta/attachments`;
+    this.container =
+      this.config.getOptionalString('qeta.storage.blobStorageContainer') ||
+      'backstage-qeta-images';
+  }
+
+  handleFile = async (
+    file: File,
+    options?: { postId?: number; answerId?: number; collectionId?: number },
+  ): Promise<Attachment> => {
+    const imageUuid = uuidv4();
+    const filename = `image-${imageUuid}-${Date.now()}.${file.ext}`;
+
+    const imageURI = `${this.qetaUrl}/${imageUuid}`;
+    const client = getAzureBlobServiceClient(this.config);
+    const container = client.getContainerClient(this.container);
+    if (!(await container.exists())) {
+        await container.create();
+    }
+
+    await container.uploadBlockBlob(filename, fs.createReadStream(file.path), file.size);
+
+    return await this.database.postAttachment({
+      uuid: imageUuid,
+      locationType: 'azure',
+      locationUri: imageURI,
+      extension: file.ext,
+      mimeType: file.mimeType,
+      path: filename,
+      binaryImage: Buffer.from('0'),
+      creator: '', // required to run locally on sqlite, otherwise it complains about null.
+      ...options,
+    });
+  };
+}
+
+export default (opts: Options) => {
+  return new AzureBlobStorageEngine(opts);
+};

--- a/plugins/qeta-backend/src/service/upload/azureBlobStorage.ts
+++ b/plugins/qeta-backend/src/service/upload/azureBlobStorage.ts
@@ -5,13 +5,14 @@ import { QetaStore } from '../../database/QetaStore';
 import { Attachment } from '@drodil/backstage-plugin-qeta-common';
 import { File } from '../types';
 import { getAzureBlobServiceClient } from '../util';
+import { AttachmentStorageEngine } from './attachmentStorageEngine';
 
 type Options = {
   config: Config;
   database: QetaStore;
 };
 
-class AzureBlobStorageEngine {
+class AzureBlobStorageEngine implements AttachmentStorageEngine {
   config: Config;
   database: QetaStore;
   backendBaseUrl: string;

--- a/plugins/qeta-backend/src/service/upload/database.ts
+++ b/plugins/qeta-backend/src/service/upload/database.ts
@@ -2,12 +2,8 @@ import { Config } from '@backstage/config';
 import { QetaStore } from '../../database/QetaStore';
 import { File } from '../types';
 import { v4 as uuidv4 } from 'uuid';
-import { AttachmentStorageEngine } from './attachmentStorageEngine';
-
-type Options = {
-  config: Config;
-  database: QetaStore;
-};
+import { AttachmentStorageEngine, AttachmentStorageEngineOptions } from './attachmentStorageEngine';
+import { Attachment } from '@drodil/backstage-plugin-qeta-common';
 
 class DatabaseStoreEngine implements AttachmentStorageEngine {
   config: Config;
@@ -15,7 +11,7 @@ class DatabaseStoreEngine implements AttachmentStorageEngine {
   backendBaseUrl: string;
   qetaUrl: string;
 
-  constructor(opts: Options) {
+  constructor(opts: AttachmentStorageEngineOptions) {
     this.config = opts.config;
     this.database = opts.database;
     this.backendBaseUrl = this.config.getString('backend.baseUrl');
@@ -39,8 +35,12 @@ class DatabaseStoreEngine implements AttachmentStorageEngine {
       ...options,
     });
   };
+
+  getAttachmentBuffer = async (attachment: Attachment) => {
+    return attachment.binaryImage;
+  };
 }
 
-export default (opts: Options) => {
+export default (opts: AttachmentStorageEngineOptions) => {
   return new DatabaseStoreEngine(opts);
 };

--- a/plugins/qeta-backend/src/service/upload/database.ts
+++ b/plugins/qeta-backend/src/service/upload/database.ts
@@ -2,13 +2,14 @@ import { Config } from '@backstage/config';
 import { QetaStore } from '../../database/QetaStore';
 import { File } from '../types';
 import { v4 as uuidv4 } from 'uuid';
+import { AttachmentStorageEngine } from './attachmentStorageEngine';
 
 type Options = {
   config: Config;
   database: QetaStore;
 };
 
-class DatabaseStoreEngine {
+class DatabaseStoreEngine implements AttachmentStorageEngine {
   config: Config;
   database: QetaStore;
   backendBaseUrl: string;

--- a/plugins/qeta-backend/src/service/upload/database.ts
+++ b/plugins/qeta-backend/src/service/upload/database.ts
@@ -39,6 +39,10 @@ class DatabaseStoreEngine implements AttachmentStorageEngine {
   getAttachmentBuffer = async (attachment: Attachment) => {
     return attachment.binaryImage;
   };
+
+  deleteAttachment = async (_attachment: Attachment) => {
+    // Nothing to do here, since the attachment is stored in the database
+  }
 }
 
 export default (opts: AttachmentStorageEngineOptions) => {

--- a/plugins/qeta-backend/src/service/upload/filesystem.ts
+++ b/plugins/qeta-backend/src/service/upload/filesystem.ts
@@ -4,13 +4,14 @@ import { Config } from '@backstage/config';
 import { QetaStore } from '../../database/QetaStore';
 import { Attachment } from '@drodil/backstage-plugin-qeta-common';
 import { File } from '../types';
+import { AttachmentStorageEngine } from './attachmentStorageEngine';
 
 type Options = {
   config: Config;
   database: QetaStore;
 };
 
-class FilesystemStoreEngine {
+class FilesystemStoreEngine implements AttachmentStorageEngine {
   config: Config;
   database: QetaStore;
   backendBaseUrl: string;

--- a/plugins/qeta-backend/src/service/upload/filesystem.ts
+++ b/plugins/qeta-backend/src/service/upload/filesystem.ts
@@ -54,6 +54,10 @@ class FilesystemStoreEngine implements AttachmentStorageEngine {
   getAttachmentBuffer = async (attachment: Attachment) => {
     return await fs.promises.readFile(attachment.path);
   };
+
+  deleteAttachment = async (attachment: Attachment) => {
+    await fs.promises.rm(attachment.path);
+  }
 }
 
 export default (opts: AttachmentStorageEngineOptions) => {

--- a/plugins/qeta-backend/src/service/upload/filesystem.ts
+++ b/plugins/qeta-backend/src/service/upload/filesystem.ts
@@ -4,12 +4,7 @@ import { Config } from '@backstage/config';
 import { QetaStore } from '../../database/QetaStore';
 import { Attachment } from '@drodil/backstage-plugin-qeta-common';
 import { File } from '../types';
-import { AttachmentStorageEngine } from './attachmentStorageEngine';
-
-type Options = {
-  config: Config;
-  database: QetaStore;
-};
+import { AttachmentStorageEngine, AttachmentStorageEngineOptions } from './attachmentStorageEngine';
 
 class FilesystemStoreEngine implements AttachmentStorageEngine {
   config: Config;
@@ -18,7 +13,7 @@ class FilesystemStoreEngine implements AttachmentStorageEngine {
   qetaUrl: string;
   folder: string;
 
-  constructor(opts: Options) {
+  constructor(opts: AttachmentStorageEngineOptions) {
     this.config = opts.config;
     this.database = opts.database;
     this.backendBaseUrl = this.config.getString('backend.baseUrl');
@@ -55,8 +50,12 @@ class FilesystemStoreEngine implements AttachmentStorageEngine {
       ...options,
     });
   };
+
+  getAttachmentBuffer = async (attachment: Attachment) => {
+    return await fs.promises.readFile(attachment.path);
+  };
 }
 
-export default (opts: Options) => {
+export default (opts: AttachmentStorageEngineOptions) => {
   return new FilesystemStoreEngine(opts);
 };

--- a/plugins/qeta-backend/src/service/upload/s3.ts
+++ b/plugins/qeta-backend/src/service/upload/s3.ts
@@ -6,13 +6,14 @@ import { Attachment } from '@drodil/backstage-plugin-qeta-common';
 import { File } from '../types';
 import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { getS3Client } from '../util';
+import { AttachmentStorageEngine } from './attachmentStorageEngine';
 
 type Options = {
   config: Config;
   database: QetaStore;
 };
 
-class S3StoreEngine {
+class S3StoreEngine implements AttachmentStorageEngine {
   config: Config;
   database: QetaStore;
   backendBaseUrl: string;

--- a/plugins/qeta-backend/src/service/util.ts
+++ b/plugins/qeta-backend/src/service/util.ts
@@ -37,6 +37,8 @@ import {
   createConditionTransformer,
 } from '@backstage/plugin-permission-node';
 import { rules } from './postRules';
+import { BlobServiceClient } from '@azure/storage-blob';
+import { DefaultAzureCredential } from '@azure/identity';
 
 export const getUsername = async (
   req: Request<unknown>,
@@ -368,3 +370,15 @@ export const getS3Client = (config: Config) => {
   }
   return new S3Client({ region });
 };
+
+export const getAzureBlobServiceClient = (config: Config) => {
+  const accountName = config.getOptionalString('qeta.storage.blobStorageAccountName');
+  const connectionString = config.getOptionalString('qeta.storage.blobStorageConnectionString');
+  if (connectionString) {
+    return BlobServiceClient.fromConnectionString(connectionString);
+  } else if (accountName) {
+    return new BlobServiceClient(`https://${accountName}.blob.core.windows.net`, new DefaultAzureCredential());
+  } else {
+    throw new Error('Either account name or connection string must be provided for Azure Blob Storage');
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -920,7 +920,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@azure/abort-controller@npm:^2.0.0":
+"@azure/abort-controller@npm:^2.0.0, @azure/abort-controller@npm:^2.1.2":
   version: 2.1.2
   resolution: "@azure/abort-controller@npm:2.1.2"
   dependencies:
@@ -940,7 +940,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@azure/core-client@npm:^1.9.2":
+"@azure/core-auth@npm:^1.9.0":
+  version: 1.9.0
+  resolution: "@azure/core-auth@npm:1.9.0"
+  dependencies:
+    "@azure/abort-controller": "npm:^2.0.0"
+    "@azure/core-util": "npm:^1.11.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/b7d8f33b81a8c9a76531acacc7af63d888429f0d763bb1ab8e28e91ddbf1626fc19cf8ca74f79c39b0a3e5acb315bdc4c4276fb979816f315712ea1bd611273d
+  languageName: node
+  linkType: hard
+
+"@azure/core-client@npm:^1.3.0, @azure/core-client@npm:^1.6.2, @azure/core-client@npm:^1.9.2":
   version: 1.9.2
   resolution: "@azure/core-client@npm:1.9.2"
   dependencies:
@@ -952,6 +963,38 @@ __metadata:
     "@azure/logger": "npm:^1.0.0"
     tslib: "npm:^2.6.2"
   checksum: 10c0/4dab1f3b070f7c2c5a8390f81c7afdf31c030ad0599e75e16b9684959fb666cb57d34b63977639a60a7535f63f30a8a708210e8e48ff68a30732b7518044ebce
+  languageName: node
+  linkType: hard
+
+"@azure/core-http-compat@npm:^2.0.0":
+  version: 2.1.2
+  resolution: "@azure/core-http-compat@npm:2.1.2"
+  dependencies:
+    "@azure/abort-controller": "npm:^2.0.0"
+    "@azure/core-client": "npm:^1.3.0"
+    "@azure/core-rest-pipeline": "npm:^1.3.0"
+  checksum: 10c0/e7b5374819d740c96c075956c756a753b7e9f6d7774bbadcc5000c3c4f808554e4d7146ccde7b94bcb21c39ed4a7e5b043b2a3b7d208b959310ea7e1440decca
+  languageName: node
+  linkType: hard
+
+"@azure/core-lro@npm:^2.2.0":
+  version: 2.7.2
+  resolution: "@azure/core-lro@npm:2.7.2"
+  dependencies:
+    "@azure/abort-controller": "npm:^2.0.0"
+    "@azure/core-util": "npm:^1.2.0"
+    "@azure/logger": "npm:^1.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/bee809e47661b40021bbbedf88de54019715fdfcc95ac552b1d901719c29d78e293eeab51257b8f5155aac768eb4ea420715004d00d6e32109f5f97db5960d39
+  languageName: node
+  linkType: hard
+
+"@azure/core-paging@npm:^1.1.1":
+  version: 1.6.2
+  resolution: "@azure/core-paging@npm:1.6.2"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/c727782f8dc66eff50c03421af2ca55f497f33e14ec845f5918d76661c57bc8e3a7ca9fa3d39181287bfbfa45f28cb3d18b67c31fd36bbe34146387dbd07b440
   languageName: node
   linkType: hard
 
@@ -971,12 +1014,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@azure/core-rest-pipeline@npm:^1.10.1, @azure/core-rest-pipeline@npm:^1.17.0, @azure/core-rest-pipeline@npm:^1.3.0":
+  version: 1.18.1
+  resolution: "@azure/core-rest-pipeline@npm:1.18.1"
+  dependencies:
+    "@azure/abort-controller": "npm:^2.0.0"
+    "@azure/core-auth": "npm:^1.8.0"
+    "@azure/core-tracing": "npm:^1.0.1"
+    "@azure/core-util": "npm:^1.11.0"
+    "@azure/logger": "npm:^1.0.0"
+    http-proxy-agent: "npm:^7.0.0"
+    https-proxy-agent: "npm:^7.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/e63d110f799a74ed20925e59ee70eced355f76130a2283393ce109b49365c97a436e8ddde29badee138c17cf0ecf33c26b9ce3cfbf64cf98b904ab50e6bdedff
+  languageName: node
+  linkType: hard
+
 "@azure/core-tracing@npm:^1.0.0, @azure/core-tracing@npm:^1.0.1":
   version: 1.1.2
   resolution: "@azure/core-tracing@npm:1.1.2"
   dependencies:
     tslib: "npm:^2.6.2"
   checksum: 10c0/0e844d581117ae81318a503ddfc143146b847ed9152d0c84f20fdc4cb0b2187a4e9da29aed13d5b7a201f39fe601a59c4db6455005ed8e0d3b5aab0ee77a56e1
+  languageName: node
+  linkType: hard
+
+"@azure/core-tracing@npm:^1.1.2":
+  version: 1.2.0
+  resolution: "@azure/core-tracing@npm:1.2.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/7cd114b3c11730a1b8b71d89b64f9d033dfe0710f2364ef65645683381e2701173c08ff8625a0b0bc65bb3c3e0de46c80fdb2735e37652425489b65a283f043d
   languageName: node
   linkType: hard
 
@@ -987,6 +1055,26 @@ __metadata:
     "@azure/abort-controller": "npm:^2.0.0"
     tslib: "npm:^2.6.2"
   checksum: 10c0/94c89ca7b4d44f85cd39e1ce77b4f4b2c2aa2bdc8230454816ba98fb5333bacd648d5ffcd73518b1d1f40405a40c3411987cfed4d260c62a07b740c7f1d77792
+  languageName: node
+  linkType: hard
+
+"@azure/core-util@npm:^1.11.0, @azure/core-util@npm:^1.2.0":
+  version: 1.11.0
+  resolution: "@azure/core-util@npm:1.11.0"
+  dependencies:
+    "@azure/abort-controller": "npm:^2.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/245c93ec7fb3f2cb3a0b2f3a3be8d02ee401acba3cdd71620aa9e4e3ca50d831849f692332327bdbe1238ab979a76218f16a5166488ee31d5b67004298d110a3
+  languageName: node
+  linkType: hard
+
+"@azure/core-xml@npm:^1.4.3":
+  version: 1.4.4
+  resolution: "@azure/core-xml@npm:1.4.4"
+  dependencies:
+    fast-xml-parser: "npm:^4.4.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/92c643a9b80272b27a7bf9b756627f21beec5289995f3188099f056d255de702e1f8959bfc0f14d7445a1f6da4d037957ba47d757545ade5e77f610c4124c3fa
   languageName: node
   linkType: hard
 
@@ -1012,6 +1100,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@azure/identity@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "@azure/identity@npm:4.5.0"
+  dependencies:
+    "@azure/abort-controller": "npm:^2.0.0"
+    "@azure/core-auth": "npm:^1.9.0"
+    "@azure/core-client": "npm:^1.9.2"
+    "@azure/core-rest-pipeline": "npm:^1.17.0"
+    "@azure/core-tracing": "npm:^1.0.0"
+    "@azure/core-util": "npm:^1.11.0"
+    "@azure/logger": "npm:^1.0.0"
+    "@azure/msal-browser": "npm:^3.26.1"
+    "@azure/msal-node": "npm:^2.15.0"
+    events: "npm:^3.0.0"
+    jws: "npm:^4.0.0"
+    open: "npm:^8.0.0"
+    stoppable: "npm:^1.1.0"
+    tslib: "npm:^2.2.0"
+  checksum: 10c0/39c7f8d85e3275daee800c72a3c50e9c77af508ca5b305986c845748443784afa0cff38c53b1ebfcde868f4563778c90b3812b9ac5fc25cd6af3b9b371b1dcc9
+  languageName: node
+  linkType: hard
+
 "@azure/logger@npm:^1.0.0":
   version: 1.1.4
   resolution: "@azure/logger@npm:1.1.4"
@@ -1030,10 +1140,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@azure/msal-browser@npm:^3.26.1":
+  version: 3.28.0
+  resolution: "@azure/msal-browser@npm:3.28.0"
+  dependencies:
+    "@azure/msal-common": "npm:14.16.0"
+  checksum: 10c0/58abe040f465e840d90a1b492651f77fe413ea0cf8dca69abd28f650dc1cc6f9872ba130a39ff19f0c7463d0a9ce4a077752de58887737650b953f00e19e7b6d
+  languageName: node
+  linkType: hard
+
 "@azure/msal-common@npm:14.14.2":
   version: 14.14.2
   resolution: "@azure/msal-common@npm:14.14.2"
   checksum: 10c0/b2b7cd72a7748ce3f8df4dd3bc7ab9b0faac3f292923459779a1263ccc0ceb251a48e7244919ac4f4cbb6cc73eaac7e196dbea0d865c2bf9d40a02a570239b30
+  languageName: node
+  linkType: hard
+
+"@azure/msal-common@npm:14.16.0":
+  version: 14.16.0
+  resolution: "@azure/msal-common@npm:14.16.0"
+  checksum: 10c0/f1a510cb7836d6990034a7f10430cb78cb61c3c972082525f08bcb9260c69ddefe2429ef2a6525f1616b1958181956371ba24350232e0eac0b4279bf8264e648
+  languageName: node
+  linkType: hard
+
+"@azure/msal-node@npm:^2.15.0":
+  version: 2.16.2
+  resolution: "@azure/msal-node@npm:2.16.2"
+  dependencies:
+    "@azure/msal-common": "npm:14.16.0"
+    jsonwebtoken: "npm:^9.0.0"
+    uuid: "npm:^8.3.0"
+  checksum: 10c0/0513a12d42fc53f8ddf5d460087621a526000054f92d1874f054736007018de583318d240576e98b5f65a598b66f19b3165b9550dfded8bf07dbcb53a21bb08e
   languageName: node
   linkType: hard
 
@@ -1045,6 +1182,27 @@ __metadata:
     jsonwebtoken: "npm:^9.0.0"
     uuid: "npm:^8.3.0"
   checksum: 10c0/9781a2a20f103090ab0ce60a4ca690a6ae2f1f1e7f55d5d1e188032a4e8c1242bc254d34a116e3df343a537b3807b53ead49267bdfb6bbb423e4c7f326dbe558
+  languageName: node
+  linkType: hard
+
+"@azure/storage-blob@npm:^12.26.0":
+  version: 12.26.0
+  resolution: "@azure/storage-blob@npm:12.26.0"
+  dependencies:
+    "@azure/abort-controller": "npm:^2.1.2"
+    "@azure/core-auth": "npm:^1.4.0"
+    "@azure/core-client": "npm:^1.6.2"
+    "@azure/core-http-compat": "npm:^2.0.0"
+    "@azure/core-lro": "npm:^2.2.0"
+    "@azure/core-paging": "npm:^1.1.1"
+    "@azure/core-rest-pipeline": "npm:^1.10.1"
+    "@azure/core-tracing": "npm:^1.1.2"
+    "@azure/core-util": "npm:^1.6.1"
+    "@azure/core-xml": "npm:^1.4.3"
+    "@azure/logger": "npm:^1.0.0"
+    events: "npm:^3.0.0"
+    tslib: "npm:^2.2.0"
+  checksum: 10c0/069b7a85dddb33ee793efd74fbc1a3377c6d14dbb11094c2ebae87e324f16d23292806d5dcdf04280456dafc4d960e847968f6f01e384039b47363d61faf1017
   languageName: node
   linkType: hard
 
@@ -4908,6 +5066,8 @@ __metadata:
   resolution: "@drodil/backstage-plugin-qeta-backend@workspace:plugins/qeta-backend"
   dependencies:
     "@aws-sdk/client-s3": "npm:^3.540.0"
+    "@azure/identity": "npm:^4.5.0"
+    "@azure/storage-blob": "npm:^12.26.0"
     "@backstage/backend-defaults": "backstage:^"
     "@backstage/backend-plugin-api": "backstage:^"
     "@backstage/backend-test-utils": "backstage:^"


### PR DESCRIPTION
This refactors the way the attachments endpoint interacts with storage engines by introducing an `AttachmentStorageEngine` interface. It then implements that interface for all existing storage engine types (database, filesystem, s3) and adds a new implementation for storing attachments in Azure Blob Storage.

Signed-off-by: Jonathan Mezach <jonathan.mezach@rr-wfm.com>