### PR TITLE
feat(search): add support to search result item extensions

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -29,30 +29,8 @@ import {
 export const searchPage = (
   <Page themeId="home">
     <SearchResult>
-      {({ results }) => (
-        <List>
-          {results.map(result => {
-            switch (result.type) {
-              case 'qeta':
-                return (
-                  <QetaSearchResultListItem
-                    key={result.document.location}
-                    result={result.document}
-                    highlight={result.highlight}
-                  />
-                );
-              default:
-                return (
-                  <DefaultResultListItem
-                    key={result.document.location}
-                    result={result.document}
-                    highlight={result.highlight}
-                  />
-                );
-            }
-          })}
-        </List>
-      )}
+      // ...
+      <QetaSearchResultListItem />
     </SearchResult>
   </Page>
 );

--- a/plugins/qeta/dev/SearchPage.tsx
+++ b/plugins/qeta/dev/SearchPage.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { Content, Header, Page } from '@backstage/core-components';
-import { Grid, List } from '@material-ui/core';
+import { Grid } from '@material-ui/core';
 import {
-  DefaultResultListItem,
   SearchBar,
   SearchContextProvider,
   SearchResult,
@@ -20,30 +19,7 @@ export const searchPage = (
           </Grid>
           <Grid item xs={9}>
             <SearchResult>
-              {({ results }) => (
-                <List>
-                  {results.map(result => {
-                    switch (result.type) {
-                      case 'qeta':
-                        return (
-                          <QetaSearchResultListItem
-                            key={result.document.location}
-                            result={result.document}
-                            highlight={result.highlight}
-                          />
-                        );
-                      default:
-                        return (
-                          <DefaultResultListItem
-                            key={result.document.location}
-                            result={result.document}
-                            highlight={result.highlight}
-                          />
-                        );
-                    }
-                  })}
-                </List>
-              )}
+              <QetaSearchResultListItem />
             </SearchResult>
           </Grid>
         </Grid>

--- a/plugins/qeta/src/components/QetaSearchResultListItem/QetaSearchResultListItem.tsx
+++ b/plugins/qeta/src/components/QetaSearchResultListItem/QetaSearchResultListItem.tsx
@@ -43,12 +43,12 @@ const useStyles = makeStyles({
   },
 });
 
-export interface QetaSearchResultProps {
+export type QetaSearchResultListItemProps = {
   result?: IndexableDocument;
   highlight?: ResultHighlight;
   rank?: number;
   hideIcon?: boolean;
-}
+};
 
 const isQetaSearchDocument = (
   document: IndexableDocument,
@@ -161,7 +161,9 @@ const ResultIcon = (props: { document: QetaSearchDocument }) => {
   return <PlaylistPlay />;
 };
 
-export const QetaSearchResultListItem = (props: QetaSearchResultProps) => {
+export const QetaSearchResultListItem = (
+  props: QetaSearchResultListItemProps,
+) => {
   const classes = useStyles();
   const { result, highlight, hideIcon } = props;
 

--- a/plugins/qeta/src/components/QetaSearchResultListItem/index.ts
+++ b/plugins/qeta/src/components/QetaSearchResultListItem/index.ts
@@ -1,1 +1,1 @@
-export { QetaSearchResultListItem } from './QetaSearchResultListItem';
+export * from './QetaSearchResultListItem';

--- a/plugins/qeta/src/components/index.ts
+++ b/plugins/qeta/src/components/index.ts
@@ -1,3 +1,2 @@
 export * from './PostsTableCard';
 export * from './Statistics';
-export * from './QetaSearchResultListItem';

--- a/plugins/qeta/src/index.ts
+++ b/plugins/qeta/src/index.ts
@@ -3,5 +3,8 @@ export {
   QetaPage,
   PostsTableCard,
   QuestionsTableCard,
+  QetaSearchResultListItem,
 } from './plugin';
 export * from './components';
+
+export type { QetaSearchResultListItemProps } from './components/QetaSearchResultListItem';

--- a/plugins/qeta/src/plugin.ts
+++ b/plugins/qeta/src/plugin.ts
@@ -6,8 +6,10 @@ import {
   fetchApiRef,
 } from '@backstage/core-plugin-api';
 import { createCardExtension } from '@backstage/plugin-home-react';
+import { createSearchResultListItemExtension } from '@backstage/plugin-search-react';
 import { qetaApiRef, qetaRouteRef } from '@drodil/backstage-plugin-qeta-react';
 import { PostType, QetaClient } from '@drodil/backstage-plugin-qeta-common';
+import type { QetaSearchResultListItemProps } from './components/QetaSearchResultListItem';
 
 export const qetaPlugin = createPlugin({
   id: 'qeta',
@@ -79,3 +81,21 @@ export const PostsTableCard = qetaPlugin.provide(
  * @deprecated Use PostsTableCard instead
  */
 export const QuestionsTableCard = PostsTableCard;
+
+/**
+ * React extension used to render results on Search page or modal
+ *
+ * @public
+ */
+export const QetaSearchResultListItem: (
+  props: QetaSearchResultListItemProps,
+) => JSX.Element | null = qetaPlugin.provide(
+  createSearchResultListItemExtension({
+    name: 'QetaSearchResultListItem',
+    component: () =>
+      import('./components/QetaSearchResultListItem').then(
+        m => m.QetaSearchResultListItem,
+      ),
+    predicate: result => result.type === 'qeta',
+  }),
+);


### PR DESCRIPTION
# Pull Request Summary

## Overview
This PR refactors the search result handling in the `qeta` plugin, simplifying rendering logic and improving modularity. The main changes focus on streamlining the `searchPage` component, enhancing type consistency, and refining exports for better reusability.

## Key Changes
- **Simplified search result rendering** by replacing redundant logic with a direct usage of `QetaSearchResultListItem`.
- **Improved type consistency** by renaming and refining `QetaSearchResultListItemProps`.
- **Enhanced module exports** to ensure better accessibility and modularity.
- **Introduced a Backstage search result extension** for structured integration within the search framework.

## Impact
- **Better maintainability** with reduced complexity in `searchPage`.
- **Improved type safety** and clearer component definitions.
- **Seamless integration** of `QetaSearchResultListItem` in Backstage search.

## References
- [How to render search results using extensions](https://backstage.io/docs/features/search/how-to-guides/#how-to-render-search-results-using-extensions)