### PR TITLE
feat: Add a simple non changing className to the AI Answer Card

### DIFF
--- a/plugins/qeta-react/src/components/AIAnswerCard/AIAnswerCard.tsx
+++ b/plugins/qeta-react/src/components/AIAnswerCard/AIAnswerCard.tsx
@@ -138,7 +138,7 @@ export const AIAnswerCard = (props: AIAnswerCardProps) => {
   }
 
   return (
-    <Card style={style} className={styles.root}>
+    <Card style={style} className={`${styles.root} qetaAIAnswerCard`}>
       <CardHeader
         avatar={<FlareIcon />}
         style={!expanded ? { paddingBottom: '1em' } : {}}


### PR DESCRIPTION
Add a simple non-changing class name to the AI Answer Card similar to what is found on the 'qetaCommentSection' class.

This is intended to hide the AI Card but still allow the functionality to run in the background - For example: Users can use this class to target the element based on a feature flag 

A more in-depth solution by adding props passed down all the way to the component can be an alternative afterwards