### PR TITLE
fix: fetch collections without attached posts

### DIFF
--- a/plugins/qeta-backend/src/database/DatabaseQetaStore.test.ts
+++ b/plugins/qeta-backend/src/database/DatabaseQetaStore.test.ts
@@ -474,6 +474,23 @@ describe.each(databases.eachSupportedId())(
         const tags2 = await storage.getUserEntities('user');
         expect(tags2).toEqual({ entityRefs: [], count: 0 });
       });
+
+      it('should return empty collections in getCollections', async () => {
+        const collection = await storage.createCollection({
+          user_ref: 'user1',
+          title: 'Empty Collection',
+          description: 'A collection with no posts',
+          created: new Date(),
+        });
+
+        const result = await storage.getCollections('user1', {});
+        const found = result.collections.find(
+          c => c.id === collection.id && c.title === 'Empty Collection',
+        );
+        expect(found).toBeDefined();
+        expect(found?.postsCount).toBe(0);
+        expect(found?.posts).toEqual([]);
+      });
     });
   },
 );


### PR DESCRIPTION
**What**

Fixes a bug where collections with no posts were not returned by the Qeta backend API. Now, all collections, including empty ones, are included in getCollections results. Bug described in #318 

**Why**

The previous SQL logic excluded collections without posts, so users could not see or manage empty collections.

**How**

- Refactored join logic in DatabaseQetaStore.ts to use left joins and moved the posts.status filter into the join condition.
- Updated filtering so collections with no posts, tags, or entities are included.
- Added a regression test in DatabaseQetaStore.test.ts to check that empty collections are returned with postsCount: 0 and posts: [].