### PR TITLE
fix: avoid querying when no mention kinds are enabled

### DIFF
--- a/plugins/qeta-react/src/components/MarkdownEditor/MarkdownEditor.tsx
+++ b/plugins/qeta-react/src/components/MarkdownEditor/MarkdownEditor.tsx
@@ -162,13 +162,16 @@ export const MarkdownEditor = (props: MarkdownEditorProps) => {
   ) || ['user'];
 
   const loadEntitySuggestions = async (text: string) => {
-    const supportedKinds = ['user', 'group'] as const;
+    const supportedKinds: readonly string[] = ['user', 'group'] as const;
     // Filter the supported kinds based on the enabled mention types
     // to ensure we only query for the kinds that are enabled.
-    const enabledKinds = supportedKinds.filter(kind =>
-      enabledMentionTypes.includes(kind.toLowerCase()),
+    const enabledKinds = enabledMentionTypes.filter(kind =>
+      supportedKinds.includes(kind.toLowerCase()),
     );
-    if (!text) {
+
+    // If no text is provided or no kinds are enabled,
+    // return an empty suggestions array.
+    if (!text || enabledKinds.length === 0) {
       return NO_SUGGESTIONS;
     }
     const entities = await catalogApi.queryEntities({


### PR DESCRIPTION
This pull request refines the logic in the `MarkdownEditor` component to improve the handling of entity suggestions. The changes ensure better filtering of enabled mention types and add a safeguard for cases where no text or enabled kinds are provided.

### Improvements to entity suggestion logic:

* [`plugins/qeta-react/src/components/MarkdownEditor/MarkdownEditor.tsx`](diffhunk://#diff-80aabd2bbbc7f85cf08ef7345e83d9525cb221362e86502256b5169b59d10dd9L165-R174): Changed the filtering logic to ensure `enabledMentionTypes` are checked against `supportedKinds` instead of the reverse, improving clarity and correctness.
* [`plugins/qeta-react/src/components/MarkdownEditor/MarkdownEditor.tsx`](diffhunk://#diff-80aabd2bbbc7f85cf08ef7345e83d9525cb221362e86502256b5169b59d10dd9L165-R174): Added a condition to return an empty suggestions array when no text is provided or when no kinds are enabled, enhancing robustness.

closes #321 