### PR TITLE
fix: replace fs.rename with fs.copyFile and fs.unlink to avoid EXDEV

### DIFF
--- a/plugins/qeta-backend/src/service/upload/filesystem.ts
+++ b/plugins/qeta-backend/src/service/upload/filesystem.ts
@@ -48,6 +48,10 @@ class FilesystemStoreEngine implements AttachmentStorageEngine {
       if (err) throw err;
       console.debug(`Successfully rename ${file.path} to ${newPath}`);
     });
+    // Replace fs.rename with fs.copyFile + fs.unlink using promises to avoid EXDEV errors
+    await fs.promises.copyFile(file.path, newPath);
+    await fs.promises.unlink(file.path);
+    console.debug(`Successfully moved ${file.path} to ${newPath}`);
 
     return await this.database.postAttachment({
       uuid: imageUuid,


### PR DESCRIPTION
Proposed fix for #325 

Replace fs.rename with fs.copyFile and fs.unlink to avoid EXDEV when using different file systems