### PR TITLE
feat: notification receivers extension point

### DIFF
--- a/plugins/qeta-backend/dev/index.ts
+++ b/plugins/qeta-backend/dev/index.ts
@@ -5,7 +5,10 @@ import {
 } from '@backstage/backend-plugin-api';
 import { policyExtensionPoint } from '@backstage/plugin-permission-node/alpha';
 import { PermissionPolicy } from './PermissionPolicy';
-import { qetaTagDatabaseExtensionPoint } from '@drodil/backstage-plugin-qeta-node';
+import {
+  qetaNotificationReceiversExtensionPoint,
+  qetaTagDatabaseExtensionPoint,
+} from '@drodil/backstage-plugin-qeta-node';
 
 const backend = createBackend();
 backend.add(import('@backstage/plugin-catalog-backend'));
@@ -57,6 +60,32 @@ backend.add(
             },
           };
           database.setTagDatabase(tagDatabase);
+        },
+      });
+    },
+  }),
+);
+
+// Example how to add custom notification receivers
+backend.add(
+  createBackendModule({
+    pluginId: 'qeta',
+    moduleId: 'notification-receivers',
+    register(reg) {
+      reg.registerInit({
+        deps: {
+          notificationReceivers: qetaNotificationReceiversExtensionPoint,
+        },
+        async init({ notificationReceivers }) {
+          notificationReceivers.setHandler({
+            onNewPost: async post => {
+              if (post.content.includes('@support')) {
+                return ['group:default/support'];
+              }
+
+              return [];
+            },
+          });
         },
       });
     },

--- a/plugins/qeta-backend/src/plugin.ts
+++ b/plugins/qeta-backend/src/plugin.ts
@@ -13,8 +13,11 @@ import { AttachmentCleaner } from './service/AttachmentCleaner';
 import { CatalogClient } from '@backstage/catalog-client';
 import {
   AIHandler,
+  NotificationReceiversHandler,
   qetaAIExtensionPoint,
   QetaAIExtensionPoint,
+  qetaNotificationReceiversExtensionPoint,
+  QetaNotificationReceiversExtensionPoint,
   qetaTagDatabaseExtensionPoint,
   QetaTagDatabaseExtensionPoint,
   TagDatabase,
@@ -48,6 +51,20 @@ class QetaTagsDatabaseExtensionPointImpl
   }
 }
 
+class QetaNotificationReceiversExtensionPointImpl
+  implements QetaNotificationReceiversExtensionPoint
+{
+  #notificationReceivers?: NotificationReceiversHandler;
+
+  get handler() {
+    return this.#notificationReceivers;
+  }
+
+  setHandler(handler: NotificationReceiversHandler) {
+    this.#notificationReceivers = handler;
+  }
+}
+
 /**
  * Qeta backend plugin
  *
@@ -61,6 +78,13 @@ export const qetaPlugin = createBackendPlugin({
 
     const tagsExtension = new QetaTagsDatabaseExtensionPointImpl();
     env.registerExtensionPoint(qetaTagDatabaseExtensionPoint, tagsExtension);
+
+    const notificationReceiversExtension =
+      new QetaNotificationReceiversExtensionPointImpl();
+    env.registerExtensionPoint(
+      qetaNotificationReceiversExtensionPoint,
+      notificationReceiversExtension,
+    );
 
     env.registerInit({
       deps: {
@@ -129,6 +153,7 @@ export const qetaPlugin = createBackendPlugin({
             aiHandler: aiExtension.aiHandler,
             permissionsRegistry,
             auditor,
+            notificationReceivers: notificationReceiversExtension.handler,
           }),
         );
         // Allowing attachments download

--- a/plugins/qeta-backend/src/service/NotificationManager.test.ts
+++ b/plugins/qeta-backend/src/service/NotificationManager.test.ts
@@ -4,12 +4,14 @@ import { LoggerService } from '@backstage/backend-plugin-api';
 import { Answer, Post } from '@drodil/backstage-plugin-qeta-common';
 import { CatalogApi } from '@backstage/catalog-client';
 import { mockServices } from '@backstage/backend-test-utils';
+import { NotificationReceiversHandler } from '@drodil/backstage-plugin-qeta-node';
 
 describe('NotificationManager', () => {
   let notificationManager: NotificationManager;
   let mockLogger: LoggerService;
   let mockNotificationService: NotificationService;
   let mockCatalog: CatalogApi;
+  let notificationReceivers: NotificationReceiversHandler;
 
   beforeEach(() => {
     mockLogger = { error: jest.fn() } as unknown as LoggerService;
@@ -21,6 +23,15 @@ describe('NotificationManager', () => {
         .fn()
         .mockResolvedValue({ metadata: { title: 'John Doe' } }),
     } as unknown as CatalogApi;
+    notificationReceivers = {
+      onNewPost: jest.fn().mockResolvedValue(['user3']),
+      onNewPostComment: jest.fn().mockResolvedValue(['user3']),
+      onNewAnswer: jest.fn().mockResolvedValue(['user3']),
+      onAnswerComment: jest.fn().mockResolvedValue(['user3']),
+      onCorrectAnswer: jest.fn().mockResolvedValue(['user3']),
+      onMention: jest.fn().mockResolvedValue(['user3']),
+    };
+
     notificationManager = new NotificationManager(
       mockLogger,
       mockCatalog,
@@ -31,6 +42,8 @@ describe('NotificationManager', () => {
       }),
       mockServices.rootConfig.mock(),
       mockNotificationService,
+      mockServices.cache.mock(),
+      notificationReceivers,
     );
   });
 
@@ -64,7 +77,7 @@ describe('NotificationManager', () => {
           topic: 'New question about entity',
         },
         recipients: {
-          entityRef: ['entity1', 'user1', 'user2'],
+          entityRef: ['entity1', 'user1', 'user2', 'user3'],
           excludeEntityRef: 'author',
           type: 'entity',
         },
@@ -118,7 +131,7 @@ describe('NotificationManager', () => {
           topic: 'New question comment',
         },
         recipients: {
-          entityRef: ['author', 'entity1', 'user1', 'user2'],
+          entityRef: ['author', 'entity1', 'user1', 'user2', 'user3'],
           excludeEntityRef: 'author',
           type: 'entity',
         },
@@ -182,7 +195,7 @@ describe('NotificationManager', () => {
           topic: 'New answer on question',
         },
         recipients: {
-          entityRef: ['author', 'entity1', 'user1', 'user2'],
+          entityRef: ['author', 'entity1', 'user1', 'user2', 'user3'],
           excludeEntityRef: 'author',
           type: 'entity',
         },
@@ -245,7 +258,7 @@ describe('NotificationManager', () => {
           topic: 'New answer comment',
         },
         recipients: {
-          entityRef: ['answerer', 'entity1', 'user1', 'user2'],
+          entityRef: ['answerer', 'entity1', 'user1', 'user2', 'user3'],
           excludeEntityRef: 'author',
           type: 'entity',
         },
@@ -307,7 +320,7 @@ describe('NotificationManager', () => {
           topic: 'Correct answer on question',
         },
         recipients: {
-          entityRef: ['answerer', 'author', 'entity1'],
+          entityRef: ['answerer', 'author', 'entity1', 'user3'],
           excludeEntityRef: 'author',
           type: 'entity',
         },
@@ -363,7 +376,7 @@ describe('NotificationManager', () => {
           topic: 'New mention',
         },
         recipients: {
-          entityRef: ['user2'],
+          entityRef: ['user2', 'user3'],
           excludeEntityRef: 'author',
           type: 'entity',
         },

--- a/plugins/qeta-backend/src/service/router.ts
+++ b/plugins/qeta-backend/src/service/router.ts
@@ -30,6 +30,7 @@ export async function createRouter(
     config,
     options.notifications,
     options.cache,
+    options.notificationReceivers,
   );
 
   const permissionMgr = new PermissionManager(

--- a/plugins/qeta-backend/src/service/types.ts
+++ b/plugins/qeta-backend/src/service/types.ts
@@ -29,7 +29,10 @@ import {
   UsersQuery,
 } from '@drodil/backstage-plugin-qeta-common';
 import { CatalogApi } from '@backstage/catalog-client';
-import { AIHandler } from '@drodil/backstage-plugin-qeta-node';
+import {
+  AIHandler,
+  NotificationReceiversHandler,
+} from '@drodil/backstage-plugin-qeta-node';
 import { PermissionManager } from './PermissionManager.ts';
 
 export interface RouterOptions {
@@ -49,6 +52,7 @@ export interface RouterOptions {
   aiHandler?: AIHandler;
   permissionsRegistry?: PermissionsRegistryService;
   auditor?: AuditorService;
+  notificationReceivers?: NotificationReceiversHandler;
 }
 
 export interface RouteOptions extends RouterOptions {

--- a/plugins/qeta-node/src/extensions.ts
+++ b/plugins/qeta-node/src/extensions.ts
@@ -5,7 +5,10 @@ import {
 } from '@backstage/backend-plugin-api';
 import {
   AIResponse,
+  Answer,
   Article,
+  Collection,
+  Post,
   Question,
 } from '@drodil/backstage-plugin-qeta-common';
 
@@ -92,4 +95,28 @@ export const qetaAIExtensionPoint = createExtensionPoint<QetaAIExtensionPoint>({
 export const qetaTagDatabaseExtensionPoint =
   createExtensionPoint<QetaTagDatabaseExtensionPoint>({
     id: 'qeta.tags',
+  });
+
+export interface NotificationReceiversHandler {
+  onNewPost?(post: Post): Promise<string[]>;
+  onNewPostComment?(post: Post): Promise<string[]>;
+  onPostDelete?(post: Post): Promise<string[]>;
+  onCollectionDelete?(collection: Collection): Promise<string[]>;
+  onAnswerDelete?(post: Post, answer: Answer): Promise<string[]>;
+  onPostEdit?(post: Post): Promise<string[]>;
+  onNewAnswer?(post: Post, answer: Answer): Promise<string[]>;
+  onAnswerComment?(post: Post, answer: Answer): Promise<string[]>;
+  onCorrectAnswer?(post: Post, answer: Answer): Promise<string[]>;
+  onMention?(post: Post | Answer): Promise<string[]>;
+  onNewCollection?(collection: Collection): Promise<string[]>;
+  onNewPostToCollection?(collection: Collection): Promise<string[]>;
+}
+
+export interface QetaNotificationReceiversExtensionPoint {
+  setHandler(handler: NotificationReceiversHandler): void;
+}
+
+export const qetaNotificationReceiversExtensionPoint =
+  createExtensionPoint<QetaNotificationReceiversExtensionPoint>({
+    id: 'qeta.notifications',
   });


### PR DESCRIPTION
Add notification receivers extension point that can be used to specify custom recipients for notifications.

The main use case for this is to enable dynamic selection of notification recipients based on external data sources, like another plugin or a third-party integration, especially in scenarios where relying on static tag experts is falls short.