### PR TITLE
fix(style): improve inline display handling for comment content

### DIFF
--- a/plugins/qeta-react/src/components/CommentSection/CommentListItem.tsx
+++ b/plugins/qeta-react/src/components/CommentSection/CommentListItem.tsx
@@ -28,7 +28,7 @@ const useStyles = makeStyles(
     },
     content: {
       display: 'inline',
-      '& *:last-child': {
+      '&>*:last-child:not(ul,ol,blockquote)': {
         display: 'inline',
       },
       lineHeight: 1.5,


### PR DESCRIPTION
- Exclude lists and blockquotes from the display style as it breaks the proper block-level formatting.
- Use direct child selector (>) to be more specific to not add the style to list items

Before:

<img width="973" height="1137" alt="Näyttökuva 2025-10-20 131036" src="https://github.com/user-attachments/assets/8007bb3d-7b77-48eb-93e6-99d2882bea9a" />

After:

<img width="1396" height="1214" alt="Näyttökuva 2025-10-20 131105" src="https://github.com/user-attachments/assets/ff5a4de4-30a2-47d1-b3e0-fe58116c9252" />