### PR TITLE
fix: Notifications for custom routes

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -4,6 +4,7 @@ The following configuration options are available for your app-config.yaml:
 
 ```yaml
 qeta:
+  route: custom-qeta # Optional: set if plugin is mounted at a custom route
   allowAnonymous: true
   allowMetadataInput: false
   permissions: false
@@ -39,6 +40,7 @@ The allowed configuration values are:
 
 ## Global
 
+- `route`, string, (optional) set a custom frontend route for the Q&A plugin. If you mount the Qeta plugin at a custom path in your Backstage app (e.g. `/custom-qeta`), set `route: custom-qeta` to ensure notifications and links use the correct path (no leading or ending forward slash). Default is `qeta`.
 - `allowAnonymous`, boolean, allows anonymous users to post questions and answers anonymously. This enables also guest users to be able to post. Adds checkbox to the forms to post as anonymous. Default is `false`
 - `allowMetadataInput`, boolean, allows `created` and `user` fields to be passed when creating questions, answers, or comments. Useful if migrating information into the system. Default is `false`
 - `allowGlobalEdits`, boolean, allows editing other users' questions and answers by any user. Only if permission framework is not in use. Default is `false`.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -30,6 +30,19 @@ This plugin integrates with the notifications plugin to send notifications to us
   - The question author
   - The entity owners if the question is related to an entity
 
+## Notification Links and Custom Routes
+
+By default, notification links use `/qeta` as the base route. If you mount the Qeta plugin at a custom path in your Backstage app, set the `qeta.route` config value to match your frontend route. This ensures that notification links direct users to the correct location.
+
+Example:
+
+```yaml
+qeta:
+  route: custom-qeta
+```
+
+All notification links (questions, answers, articles, collections, etc.) will use this custom route as the base path.
+
 ## Setup
 
 To enable notifications, you need to have the notifications plugin installed and configured.

--- a/plugins/qeta-backend/src/service/NotificationManager.test.ts
+++ b/plugins/qeta-backend/src/service/NotificationManager.test.ts
@@ -84,6 +84,51 @@ describe('NotificationManager', () => {
       });
     });
 
+    it('should send notifications to the correct recipients with custom route', async () => {
+      // create new instance with custom config
+      notificationManager = new NotificationManager(
+        mockLogger,
+        mockCatalog,
+        mockServices.auth.mock({
+          getPluginRequestToken: jest
+            .fn()
+            .mockResolvedValue({ token: 'test_token' }),
+        }),
+        mockServices.rootConfig({
+          data: {
+            qeta: {
+              route: 'custom-qeta',
+            },
+          },
+        }),
+        mockNotificationService,
+        mockServices.cache.mock(),
+        notificationReceivers,
+      );
+
+      const followingUsers = ['user1', 'user2'];
+
+      await notificationManager.onNewPost(
+        'author',
+        post as Post,
+        followingUsers,
+      );
+
+      expect(mockNotificationService.send).toHaveBeenCalledWith({
+        payload: {
+          description: 'John Doe asked a question: Test Post',
+          link: '/custom-qeta/questions/1',
+          title: 'New question',
+          topic: 'New question about entity',
+        },
+        recipients: {
+          entityRef: ['entity1', 'user1', 'user2', 'user3'],
+          excludeEntityRef: 'author',
+          type: 'entity',
+        },
+      });
+    });
+
     it('should log an error if notification sending fails', async () => {
       const followingUsers = ['user1', 'user2'];
       mockNotificationService.send = jest

--- a/plugins/qeta-backend/src/service/NotificationManager.ts
+++ b/plugins/qeta-backend/src/service/NotificationManager.ts
@@ -20,6 +20,8 @@ import { NotificationReceiversHandler } from '@drodil/backstage-plugin-qeta-node
 
 export class NotificationManager {
   private readonly enabled: boolean;
+  private readonly basePath: string;
+
   constructor(
     private readonly logger: LoggerService,
     private readonly catalog: CatalogApi,
@@ -30,6 +32,9 @@ export class NotificationManager {
     private readonly notificationReceivers?: NotificationReceiversHandler,
   ) {
     this.enabled = config.getOptionalBoolean('qeta.notifications') ?? true;
+    this.basePath = (
+      this.config.getOptionalString('qeta.route') || 'qeta'
+    ).replace(/^\/+|\/+$/g, '');
   }
 
   async onNewPost(
@@ -232,7 +237,7 @@ export class NotificationManager {
               collection.title
             }" with reason: ${reason || 'No reason provided'}`,
           ),
-          link: `/qeta/collections/${collection.id}`,
+          link: `/${this.basePath}/collections/${collection.id}`,
           topic: `Collection deleted`,
           scope: `collection:delete:${collection.id}`,
         },
@@ -287,7 +292,7 @@ export class NotificationManager {
               post.title
             }" with reason: ${reason || 'No reason provided'}`,
           ),
-          link: `/qeta/questions/${post.id}`,
+          link: `/${this.basePath}/questions/${post.id}`,
           topic: `Answer deleted`,
           scope: `answer:delete:${answer.id}`,
         },
@@ -387,7 +392,7 @@ export class NotificationManager {
           description: this.formatDescription(
             `${user} answered question "${question.title}": ${answer.content}`,
           ),
-          link: `/qeta/questions/${question.id}#answer_${answer.id}`,
+          link: `/${this.basePath}/questions/${question.id}#answer_${answer.id}`,
           topic: 'New answer on question',
           scope: `question:answer:${question.id}:author`,
         },
@@ -445,7 +450,7 @@ export class NotificationManager {
           description: this.formatDescription(
             `${user} commented on answer to "${question.title}": ${comment}`,
           ),
-          link: `/qeta/questions/${question.id}#answer_${answer.id}`,
+          link: `/${this.basePath}/questions/${question.id}#answer_${answer.id}`,
           topic: 'New answer comment',
           scope: `answer:comment:${answer.id}`,
         },
@@ -497,7 +502,7 @@ export class NotificationManager {
           description: this.formatDescription(
             `${user} marked answer as correct: ${answer.content}`,
           ),
-          link: `/qeta/questions/${question.id}#answer_${answer.id}`,
+          link: `/${this.basePath}/questions/${question.id}#answer_${answer.id}`,
           topic: 'Correct answer on question',
           scope: `question:correct:${question.id}:answer`,
         },
@@ -542,7 +547,7 @@ export class NotificationManager {
             post.content
           }`;
       const link = !isPost
-        ? `/qeta/questions/${post.postId}#answer_${post.id}`
+        ? `/${this.basePath}/questions/${post.postId}#answer_${post.id}`
         : this.selectPostRoute(post.type, post.id);
       const scope = isPost
         ? `post:mention:${post.id}`
@@ -597,7 +602,7 @@ export class NotificationManager {
 
       const description = `${user} created a new collection: ${collection.title}`;
       // eslint-disable-next-line no-nested-ternary
-      const link = `/qeta/collections/${collection.id}`;
+      const link = `/${this.basePath}/collections/${collection.id}`;
       const scope = `collection:${collection.id}:created`;
 
       await this.notifications.send({
@@ -649,7 +654,7 @@ export class NotificationManager {
 
       const description = `${user} added a new post to ${collection.title}`;
       // eslint-disable-next-line no-nested-ternary
-      const link = `/qeta/collections/${collection.id}`;
+      const link = `/${this.basePath}/collections/${collection.id}`;
       const scope = `collection:${collection.id}:new_post`;
 
       await this.notifications.send({
@@ -707,9 +712,9 @@ export class NotificationManager {
   }
 
   private selectPostRoute(type: PostType, id: number) {
-    const questionRoute = `/qeta/questions/${id}`;
-    const articleRoute = `/qeta/articles/${id}`;
-    const linkRoute = `/qeta/links/${id}`;
+    const questionRoute = `/${this.basePath}/questions/${id}`;
+    const articleRoute = `/${this.basePath}/articles/${id}`;
+    const linkRoute = `/${this.basePath}/links/${id}`;
     return selectByPostType(type, questionRoute, articleRoute, linkRoute);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3272,7 +3272,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/ui@backstage:^::backstage=1.45.3&npm=0.9.1, @backstage/ui@npm:^0.9.1":
+"@backstage/ui@backstage:^::backstage=1.45.3&npm=0.9.1, @backstage/ui@npm:^0.9.0, @backstage/ui@npm:^0.9.1":
   version: 0.9.1
   resolution: "@backstage/ui@npm:0.9.1"
   dependencies:
@@ -3289,26 +3289,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/b0a9e3af46974584da3f84e3955d45744f3e5a0470a00ad9fd0e313142232212ff21dd932d6852ad29630be83d3185f260ca94349e15087be9b2f5ea8b2084e8
-  languageName: node
-  linkType: hard
-
-"@backstage/ui@npm:^0.9.0":
-  version: 0.9.0
-  resolution: "@backstage/ui@npm:0.9.0"
-  dependencies:
-    "@remixicon/react": "npm:^4.6.0"
-    "@tanstack/react-table": "npm:^8.21.3"
-    clsx: "npm:^2.1.1"
-    react-aria-components: "npm:^1.13.0"
-  peerDependencies:
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: ^6.3.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/61d4805158f5b707d86dc911d19610fd87c2681c829da84bda45fd3f977f6ac85a5413fae94dc9026bed869b32d9addd44b2d7ee35e7515ea2b6d5e58530314c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
When mounting qeta to a custom route in your application, you need to set the route value to ensure that notifications are created with the correct route on any links provided to the user.