### PR TITLE
fix: adjust inline code formatting in MarkdownRenderer #397

### DIFF
--- a/plugins/qeta-react/src/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/plugins/qeta-react/src/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -124,11 +124,7 @@ const useStyles = makeStyles(
         '& code': {
           fontFamily: 'Courier New,Courier,monospace',
           fontStyle: 'normal',
-          display: 'block',
-          width: '100%',
           overflowX: 'auto',
-          borderRadius: 4,
-          padding: '0.2em 0.4em',
         },
         '& em': {
           fontStyle: 'italic !important',


### PR DESCRIPTION
After the fix the file looks like this:

<img width="585" height="436" alt="image" src="https://github.com/user-attachments/assets/cef18061-6925-448b-b2b8-321015cd3978" />

I also tested it with a large code block. It looks and behaves also correctly.