### PR TITLE
Add postId and answerId fields to mapComment() return value

### DIFF
--- a/plugins/qeta-backend/src/database/stores/CommentsStore.ts
+++ b/plugins/qeta-backend/src/database/stores/CommentsStore.ts
@@ -223,6 +223,8 @@ export class CommentsStore extends BaseStore {
       created: val.created,
       updated: val.updated,
       updatedBy: val.updatedBy,
+      postId: val.postId,
+      answerId: val.answerId,
       status: val.status as AnswerCommentStatus,
     };
   }


### PR DESCRIPTION
fix(backend): add postId and answerId to Comment type for permission validation

## Problem

Permission policies using conditional decisions fail when editing/deleting comments:
``Error: Invalid resource type at PermissionManager.getResourceRef``

The ``isComment()`` type guard requires ``postId`` field:
```typescript
const isComment = (entity) => {
  return "postId" in entity && !("correct" in entity);
};
```

``mapComment()`` does not include ``postId`` and ``answerId``, causing validation to fail.

## Changes
Add ``postId`` and ``answerId`` fields to ``mapComment()`` return value
Fields already exist in database rows, just need to be included in mapped result

## Impact
``getPostComments()`` and ``getAnswerComments()`` already add these fields manually - no breaking changes
``getComment()`` gets the missing fields - bug fixed
All consuming code already handles these fields

## Testing
Verified with conditional permission policies:

Edit/delete comment on post
Edit/delete comment on answer