### PR TITLE
fix(qeta-backend): filter for answer ids like for posts when part of options

### DIFF
--- a/plugins/qeta-backend/src/database/stores/AnswersStore.ts
+++ b/plugins/qeta-backend/src/database/stores/AnswersStore.ts
@@ -83,6 +83,10 @@ export class AnswersStore extends BaseStore {
       query.where('answers.postId', '=', options.questionId);
     }
 
+    if (options.ids && options.ids.length > 0) {
+      query.whereIn('answers.id', options.ids);
+    }
+
     if (options.noVotes) {
       query.whereNull('answer_votes.answerId');
     }


### PR DESCRIPTION
## Problem

`AnswersStore.getAnswers()` silently ignores `options.ids`, whereas `PostsStore.getPosts()` already handles it correctly via `query.whereIn("posts.id", options.ids)`.

This is a problem for permission enforcement. The permission framework's `getResources` callback (registered via `permissionsRegistry.addResourceType`) calls:

```ts
const answers = await database.getAnswers("", { ids: answerIds }, undefined, opts);
return answers.answers;
```

Because `options.ids` is ignored, `getAnswers` returns all answers from the database instead of the specific ones requested.

Backstage's `apply-conditions` endpoint then maps resource refs to resources by index:

```ts
Object.fromEntries(uniqueRefs.map((ref, index) => [ref, resources[index]]))
// e.g. { 'qeta:answer:123': resources[0] }  ← always the first answer in the DB
```

Every answer ref — regardless of which answer the user is actually editing — gets mapped to `resources[0]`, which is the first answer ever created in the database.

## Impact

- **Edit/delete answer** permissions are broken in production for all users.
- **Entity-owner policies** (`HAS_ANY_ENTITIES` rule) are also broken for answers, since the wrong answer's post is evaluated.
- The bug does not affect posts or comments, as their respective stores already apply the ids filter.

## Fix

Add the missing `ids` filter in `getAnswers`, mirroring the existing logic in `getPosts`:

```ts
if (options.ids && options.ids.length > 0) {
  query.whereIn('answers.id', options.ids);
}
```

## Steps to reproduce

1. Run a Backstage instance with `qeta.permissions: true` and a persistent database containing answers from multiple users.
2. Log in as a user who has created answers.
3. Attempt to edit or delete one of your own answers.
4. The request is denied despite you being the author.

Disclaimer: analysis, solution and description created with AI support
Change tested in a local Backstage instance, problem confirmed on our production Backstage instance.