### PR TITLE
fix(qeta-backend): resolve pg_trgm word-similarity operator error in …

### DIFF
--- a/plugins/qeta-backend/src/database/stores/BaseStore.ts
+++ b/plugins/qeta-backend/src/database/stores/BaseStore.ts
@@ -44,7 +44,7 @@ export abstract class BaseStore {
           .join(` || ' ' || `);
 
         terms.forEach(term => {
-          builder.andWhereRaw(`(${coalescedColumns}) %> ?`, [term]);
+          builder.andWhereRaw(`(${coalescedColumns}) %> ?::text`, [term]);
         });
 
         const concatenatedColumns = `LOWER(CONCAT(${columns.join(',')}))`;
@@ -208,7 +208,27 @@ export abstract class BaseStore {
             SELECT 1 FROM pg_extension WHERE extname = 'pg_trgm'
           ) as available
         `);
-        this.pgTrgmAvailable = result.rows?.[0]?.available ?? false;
+        const extensionAvailable = result.rows?.[0]?.available ?? false;
+        if (!extensionAvailable) {
+          this.pgTrgmAvailable = false;
+          return;
+        }
+
+        // The extension being installed does not guarantee that the
+        // word-similarity operators (e.g. `%>`) are available, since they
+        // were only added in pg_trgm 1.3+. Verify the operator actually
+        // works before relying on it in queries.
+        try {
+          await this.db.raw(`SELECT 'a'::text %> 'a'::text`);
+          this.pgTrgmAvailable = true;
+        } catch (operatorError) {
+          console.warn(
+            `pg_trgm extension is installed but the "%>" operator is unavailable ` +
+              `(the extension may need to be updated, e.g. "ALTER EXTENSION pg_trgm UPDATE"). ` +
+              `Falling back to LIKE-based search: ${operatorError}`,
+          );
+          this.pgTrgmAvailable = false;
+        }
       } catch (error) {
         console.warn(`Failed to check for pg_trgm extension: ${error}`);
         this.pgTrgmAvailable = false;


### PR DESCRIPTION
…search queries

Explicitly cast the search term parameter to text (`%> ?::text`) in BaseStore.applySearchQuery, since PostgreSQL cannot resolve custom extension operators like pg_trgm's `%>` against untyped bind parameters, causing "operator does not exist: text %> unknown".

Also harden initializePgTrgm() to verify the `%>` operator actually works (not just that the pg_trgm extension is installed), since the operator was only added in pg_trgm 1.3+ and may be missing on older or un-upgraded extension versions. Falls back to LIKE-based search when unavailable.