### PR TITLE
fix: Fixed issue in the search backend caused by deprecation of TaskS…

### DIFF
--- a/plugins/search-backend-module-qeta/configSchema.d.ts
+++ b/plugins/search-backend-module-qeta/configSchema.d.ts
@@ -1,4 +1,4 @@
-import { TaskScheduleDefinitionConfig } from '@backstage/backend-plugin-api';
+import { SchedulerServiceTaskScheduleDefinitionConfig } from '@backstage/backend-plugin-api';
 
 export interface Config {
   search?: {
@@ -10,7 +10,7 @@ export interface Config {
         /**
          * The schedule for how often to run the collation job.
          */
-        schedule?: TaskScheduleDefinitionConfig;
+        schedule?: SchedulerServiceTaskScheduleDefinitionConfig;
       };
     };
   };


### PR DESCRIPTION
The search-backend-module-qeta schema referenced TaskScheduleDefinitionConfig from @backstage/backend-plugin-api which has been replaced with SchedulerServiceTaskScheduleDefinitionConfig from the same package. 

I assume this is a valid change since the qeta-backend schema already references the replacement.

Refs: #430